### PR TITLE
🔒 [security fix] Fix command injection in convert.sh

### DIFF
--- a/upstream/converter/convert.sh
+++ b/upstream/converter/convert.sh
@@ -396,18 +396,16 @@ if [[ -e ISODIR ]]; then
   rm -rf ISODIR
 fi
 
-list=
+grep_args=()
 for i in "${editions[@]}"; do
-  list="${list} -ie \"${i}""_..-.*.esd\""
+  grep_args+=("-ie" "${i}_..-.*.esd")
 done
 
-metadataFiles=$(find "$uupDir" 2>/dev/null | eval grep "$list")
+metadataFiles=$(find "$uupDir" 2>/dev/null | grep "${grep_args[@]}")
 if [[ $? != 0 ]]; then
   echo -e "${errorColor}""No metadata ESDs found.""$resetColor"
   exit 1
 fi
-
-list=
 
 firstMetadata=$(head -1 <<<"$metadataFiles")
 getLang=$(wimlib-imagex info "$firstMetadata" 3)
@@ -539,13 +537,12 @@ wimlib-imagex extract "$firstMetadata" 3 "/Windows/System32/xmllite.dll" \
 wimlib-imagex info ISODIR/sources/boot.wim 2 --image-property FLAGS=2 >/dev/null
 wimlib-imagex info ISODIR/sources/boot.wim 2 --boot >/dev/null
 
-list=
+grep_args=()
 for i in "${bootSourcesList[@]}"; do
-  list="${list} -oie \"${i}\""
+  grep_args+=("-oie" "${i}")
 done
 
-files=$(find ISODIR -regex ".*/sources/.*" | eval grep "$list")
-list=
+files=$(find ISODIR -regex ".*/sources/.*" | grep "${grep_args[@]}")
 
 echo "delete /Windows/System32/winpeshl.ini" >"${tempDir}/update.txt"
 echo "add ISODIR/setup.exe /setup.exe" >>"${tempDir}/update.txt"


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Command injection vulnerability in `upstream/converter/convert.sh` caused by the use of `eval` on a string constructed from user-controlled variables (`editions` and `bootSourcesList`).

### ⚠️ Risk: The potential impact if left unfixed
An attacker could provide a malicious edition name or boot source path containing shell metacharacters (e.g., `$(command)`) which would be executed with the privileges of the script runner. This could lead to arbitrary code execution, data loss, or system compromise.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix replaces the vulnerable `eval grep "$list"` pattern with a safe Bash array approach. By populating an array `grep_args` with the desired flags and patterns and expanding it as `"${grep_args[@]}"`, each element is passed as a separate argument to `grep`. This prevents the shell from performing further expansions or word splitting on the contents of the variables, effectively neutralizing the command injection vector.

---
*PR created automatically by Jules for task [4588502192769797460](https://jules.google.com/task/4588502192769797460) started by @Ven0m0*