### PR TITLE
🧹 [Code Health] Dedup logging functions into scripts/utils.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,21 +18,11 @@ set -euo pipefail
 
 # Resolve paths
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 UUP_DIR="$PROJECT_ROOT/uup_files"
 OUTPUT_DIR="$PROJECT_ROOT/output"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 # Run prerequisite validation
 log_info "Running prerequisite validation..."

--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -11,21 +11,11 @@
 set -euo pipefail
 
 WIM_FILE="$1"
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 CONFIG_FILE="$PROJECT_ROOT/config/debloat_list.txt"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
-
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 if [[ -z "${WIM_FILE:-}" ]]; then
     log_error "No WIM file specified."

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -7,17 +7,9 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 log_info "Checking and installing dependencies..."
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# =============================================================================
+# utils.sh - Shared utility functions for Debloated Windows 11 ISO Builder
+# =============================================================================
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -9,19 +9,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 ERRORS=0
 WARNINGS=0


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is duplicate logging functions and color definitions across multiple shell scripts (`build.sh`, `debloat_wim.sh`, `setup_env.sh`, and `validate_prereqs.sh`).
💡 **Why:** Centralizing these functions into a single `utils.sh` file improves maintainability and readability, reducing code duplication.
✅ **Verification:** Re-ran `make validate` and `bash scripts/build.sh` to ensure the logging functions still work properly and no syntax errors were introduced. The correct output was verified.
✨ **Result:** The codebase is cleaner and any future changes to logging or colors only need to be made in one place.

---
*PR created automatically by Jules for task [1186860118322021972](https://jules.google.com/task/1186860118322021972) started by @Ven0m0*