### PR TITLE
🧹 Refactor logging functions into shared utils.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,21 +18,12 @@ set -euo pipefail
 
 # Resolve paths
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 UUP_DIR="$PROJECT_ROOT/uup_files"
 OUTPUT_DIR="$PROJECT_ROOT/output"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
 
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 # Run prerequisite validation
 log_info "Running prerequisite validation..."

--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -12,20 +12,11 @@ set -euo pipefail
 
 WIM_FILE="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/utils.sh"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 CONFIG_FILE="$PROJECT_ROOT/config/debloat_list.txt"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
 
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 if [[ -z "${WIM_FILE:-}" ]]; then
     log_error "No WIM file specified."

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -6,18 +6,10 @@
 # =============================================================================
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
 
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 log_info "Checking and installing dependencies..."
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# =============================================================================
+# utils.sh - Shared utility functions for Debloated Windows 11 ISO Builder
+# =============================================================================
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -9,19 +9,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
 
-log_info() { echo -e "${CYAN}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 ERRORS=0
 WARNINGS=0


### PR DESCRIPTION
🎯 **What:** Extracted duplicated logging functions (log_info, log_success, log_warn, log_error) and their associated color definitions from `validate_prereqs.sh`, `build.sh`, `debloat_wim.sh`, and `setup_env.sh` into a new, centralized `scripts/utils.sh` file.
💡 **Why:** This significantly improves code maintainability and readability by adhering to the DRY (Don't Repeat Yourself) principle. Future changes to logging behavior or colors will now only need to be made in one place.
✅ **Verification:** Tested via `bash -n` to ensure no syntax errors were introduced, and ran `make validate` to verify the script properly sources `utils.sh` and executes identically. Verified that `$SCRIPT_DIR` was established prior to the source command in all target scripts.
✨ **Result:** Reduced duplicate code across 4 core scripts and created a clean foundation for future shared utility functions.

---
*PR created automatically by Jules for task [2772886542941272647](https://jules.google.com/task/2772886542941272647) started by @Ven0m0*