### PR TITLE
🧹 Extract argument parsing to parse_args() in download_uup.py

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -373,7 +373,7 @@ def interactive_mode(output_dir):
             return False
 
 
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         description="Download UUP files from uupdump.net for Windows 11 ISO building",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -408,7 +408,11 @@ For more information, visit: https://uupdump.net
         help="Maximum number of builds to list (default: 10)",
     )
 
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
 
     # Check dependencies
     if not check_dependencies():


### PR DESCRIPTION
🎯 **What:** The main function in scripts/download_uup.py was overly long and complex, handling both argument parsing and script execution. The argument parsing logic has been extracted into a separate parse_args() function.
💡 **Why:** This refactoring improves the readability and maintainability of the script by separating concerns. It's a standard Python pattern to keep the main() function focused on high-level orchestration.
✅ **Verification:** I ran flake8 and black to ensure code formatting and linting remain pristine. I also manually tested the script with python3 scripts/download_uup.py --help to verify that argument parsing still works exactly as before.
✨ **Result:** The main() function is now much shorter and easier to understand, making future modifications to the script simpler and less error-prone.

---
*PR created automatically by Jules for task [8321845109843702373](https://jules.google.com/task/8321845109843702373) started by @Ven0m0*