### PR TITLE
⚡ Optimize UUP download by removing redundant API call

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -203,9 +203,10 @@ def select_editions(build_info):
     return None
 
 
-def download_build(build_id, output_dir, edition_filter=None):
+def download_build(build_id, output_dir, edition_filter=None, build_info=None):
     """Download UUP files for a specific build"""
-    build_info = get_build_info(build_id)
+    if build_info is None:
+        build_info = get_build_info(build_id)
 
     if not build_info:
         log_error("Failed to get build information")
@@ -348,8 +349,14 @@ def interactive_mode(output_dir):
                 )
                 print(f"{Colors.BOLD}Build ID:{Colors.RESET} {build_id}")
 
+                # Fetch build info once
+                build_info = get_build_info(build_id)
+                if not build_info:
+                    log_error("Failed to get build information")
+                    return False
+
                 # Ask for edition selection
-                edition_filter = select_editions(get_build_info(build_id))
+                edition_filter = select_editions(build_info)
 
                 confirm = (
                     input(
@@ -359,7 +366,7 @@ def interactive_mode(output_dir):
                     .lower()
                 )
                 if confirm == "" or confirm == "y":
-                    return download_build(build_id, output_dir, edition_filter)
+                    return download_build(build_id, output_dir, edition_filter, build_info)
                 else:
                     log_info("Download cancelled")
                     return False


### PR DESCRIPTION
### ⚡ Performance Optimization: UUP Metadata Fetching

#### 💡 What:
I have optimized the `scripts/download_uup.py` script by eliminating a redundant API call to `get_build_info` during the interactive download process.

#### 🎯 Why:
Previously, `interactive_mode` would call `get_build_info` to allow the user to select editions, and then `download_build` would call it again to get the same data. This optimization fetches the data once and passes it through the flow, which is more efficient and reduces the load on the upstream API.

#### 📊 Measured Improvement:
Using a reproduction script (`tests/repro_perf.py`), I verified that the number of calls to `get_build_info` (which performs a network request) was reduced from **2 to 1** for a single build download in interactive mode. This represents a 50% reduction in metadata-related network overhead for this common user path.

#### ✅ Verification:
- Created and ran a reproduction test to confirm the call count reduction.
- Ran existing unit tests in `tests/test_download_uup.py` to ensure no functionality was broken.
- Verified that the logic correctly falls back to fetching build info if it's not provided (maintaining backward compatibility).

---
*PR created automatically by Jules for task [2462257468144086545](https://jules.google.com/task/2462257468144086545) started by @Ven0m0*