### PR TITLE
🧪 [testing] implement unit tests for select_editions

### DIFF
--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -200,5 +200,83 @@ class TestGetLatestBuilds(unittest.TestCase):
         mock_log_error.assert_called_once()
         self.assertTrue(mock_log_error.call_args[0][0].startswith("Failed to parse JSON response:"))
 
+
+class TestSelectEditions(unittest.TestCase):
+    @patch("download_uup.log_warn")
+    def test_select_editions_no_esd_files(self, mock_log_warn):
+        build_info = {"files": {"test.txt": {"size": 100}}}
+        result = download_uup.select_editions(build_info)
+        self.assertIsNone(result)
+        mock_log_warn.assert_called_with("No edition-specific files found, will download all files")
+
+    @patch("download_uup.log_warn")
+    def test_select_editions_no_matching_esd_files(self, mock_log_warn):
+        build_info = {"files": {"unknown.esd": {"size": 100}}}
+        result = download_uup.select_editions(build_info)
+        self.assertIsNone(result)
+        mock_log_warn.assert_called_with("No edition-specific files found, will download all files")
+
+    @patch("builtins.input", return_value="")
+    def test_select_editions_empty_choice(self, mock_input):
+        build_info = {
+            "files": {
+                "Windows_Professional.esd": {"size": 100},
+                "Windows_Home.esd": {"size": 100}
+            }
+        }
+        result = download_uup.select_editions(build_info)
+        self.assertIsNone(result)
+
+    @patch("builtins.input", return_value="A")
+    def test_select_editions_all_choice(self, mock_input):
+        build_info = {
+            "files": {
+                "Windows_Professional.esd": {"size": 100}
+            }
+        }
+        result = download_uup.select_editions(build_info)
+        self.assertIsNone(result)
+
+    @patch("builtins.input", return_value="1")
+    def test_select_editions_valid_choice(self, mock_input):
+        # We need to be careful with the order of editions because it uses list(edition_files.keys())
+        # Python 3.7+ dicts are ordered, so "professional" then "home"
+        build_info = {
+            "files": {
+                "Windows_Professional.esd": {"size": 100},
+                "Windows_Home.esd": {"size": 100}
+            }
+        }
+        result = download_uup.select_editions(build_info)
+        # It should return a list with the filename
+        # editions = ["professional", "home"]
+        # choice "1" -> idx 0 -> edition_files["professional"] -> "Windows_Professional.esd"
+        self.assertEqual(result, ["Windows_Professional.esd"])
+
+    @patch("download_uup.log_warn")
+    @patch("builtins.input", return_value="invalid")
+    def test_select_editions_non_numeric_choice(self, mock_input, mock_log_warn):
+        build_info = {
+            "files": {
+                "Windows_Professional.esd": {"size": 100}
+            }
+        }
+        result = download_uup.select_editions(build_info)
+        self.assertIsNone(result)
+        mock_log_warn.assert_called_with("Invalid selection, downloading all editions")
+
+    @patch("download_uup.log_warn")
+    @patch("builtins.input", return_value="99")
+    def test_select_editions_out_of_range_choice(self, mock_input, mock_log_warn):
+        build_info = {
+            "files": {
+                "Windows_Professional.esd": {"size": 100}
+            }
+        }
+        result = download_uup.select_editions(build_info)
+        self.assertIsNone(result)
+        mock_log_warn.assert_called_with("Invalid selection, downloading all editions")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `select_editions` function in `scripts/download_uup.py`.
📊 **Coverage:** The new `TestSelectEditions` class covers the following scenarios:
- `test_select_editions_no_esd_files`: Handles cases where no ESD files are present.
- `test_select_editions_no_matching_esd_files`: Handles cases where ESD files exist but don't match known edition keywords.
- `test_select_editions_empty_choice`: Verifies that empty input defaults to "All editions".
- `test_select_editions_all_choice`: Verifies that input 'A' defaults to "All editions".
- `test_select_editions_valid_choice`: Verifies that a valid numeric selection returns the correct filename.
- `test_select_editions_non_numeric_choice`: Verifies that invalid strings default to "All editions" with a warning.
- `test_select_editions_out_of_range_choice`: Verifies that out-of-range numbers default to "All editions" with a warning.
✨ **Result:** Improved test coverage for the interactive UUP downloader, ensuring user input handling and edition filtering logic are robust and well-tested.

---
*PR created automatically by Jules for task [8939931845628599440](https://jules.google.com/task/8939931845628599440) started by @Ven0m0*