### PR TITLE
🔒 Fix path traversal vulnerability in output directory validation

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -466,7 +466,9 @@ def main():
     if not output_dir.is_absolute():
         output_dir = project_root.joinpath(output_dir)
 
-    if not str(output_dir.resolve()).startswith(str(project_root.resolve())):
+    try:
+        output_dir.resolve().relative_to(project_root.resolve())
+    except (ValueError, RuntimeError):
         log_error(f"Path traversal attempt detected for output: {args.output}")
         return 1
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,50 @@
+import unittest
+from pathlib import Path
+import sys
+
+# Add the scripts directory to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+class TestSecurity(unittest.TestCase):
+    def test_path_traversal_logic(self):
+        """
+        Verify that the path validation logic correctly identifies traversal attempts,
+        including the prefix-based exploit.
+        """
+        # We'll use a mock project root for testing
+        project_root = Path("/tmp/project_root").resolve()
+
+        def is_safe(output_arg, root):
+            # This replicates the logic in download_uup.main()
+            output_dir = Path(output_arg)
+            if not output_dir.is_absolute():
+                output_dir = root.joinpath(output_dir)
+
+            try:
+                output_dir.resolve().relative_to(root.resolve())
+                return True
+            except (ValueError, RuntimeError):
+                return False
+
+        # Normal case
+        self.assertTrue(is_safe("uup_files", project_root))
+
+        # Current directory (should be allowed)
+        self.assertTrue(is_safe(".", project_root))
+
+        # Subdirectory (should be allowed)
+        self.assertTrue(is_safe("uup_files/subdir", project_root))
+
+        # Direct traversal
+        self.assertFalse(is_safe("../outside", project_root))
+
+        # Prefix exploit (The Vulnerability)
+        # If project_root is /tmp/project_root
+        # and output is /tmp/project_root_secret
+        # it should be detected as traversal
+        prefix_exploit_path = "/tmp/project_root_secret"
+        self.assertFalse(is_safe(prefix_exploit_path, project_root),
+                         f"Path {prefix_exploit_path} should be detected as traversal from {project_root}")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in the output directory validation logic in `scripts/download_uup.py`.
⚠️ **Risk:** The previous implementation used `startswith` on string paths, which allowed attackers to specify output directories that were prefixes of the intended project root (e.g., `/tmp/project-secret` when the root was `/tmp/project`), potentially leading to file writes outside the intended directory.
🛡️ **Solution:** Replaced the flawed string-based check with a robust path-aware check using `Path.relative_to()`. This ensures that the resolved output directory is strictly within the project root. Added a new security test suite to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [15917282388995824576](https://jules.google.com/task/15917282388995824576) started by @Ven0m0*