### PR TITLE
🔒 Fix Path Traversal Prevention bypass using startswith in download_uup.py

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -257,9 +257,7 @@ def _run_aria2_download(output_path, aria2_input, download_list):
                 or "\n" in item["name"]
                 or "\r" in item["name"]
             ):
-                log_error(
-                    f"Invalid characters in URL or filename: {item['name']}"
-                )
+                log_error(f"Invalid characters in URL or filename: {item['name']}")
                 return False
 
             f.write(f"{item['url']}\n")
@@ -397,7 +395,9 @@ def interactive_mode(output_dir):
                     .lower()
                 )
                 if confirm == "" or confirm == "y":
-                    return download_build(build_id, output_dir, edition_filter, build_info=build_info)
+                    return download_build(
+                        build_id, output_dir, edition_filter, build_info=build_info
+                    )
                 else:
                     log_info("Download cancelled")
                     return False
@@ -466,7 +466,9 @@ def main():
     if not output_dir.is_absolute():
         output_dir = project_root.joinpath(output_dir)
 
-    if not str(output_dir.resolve()).startswith(str(project_root.resolve())):
+    try:
+        output_dir.resolve().relative_to(project_root.resolve())
+    except (ValueError, RuntimeError):
         log_error(f"Path traversal attempt detected for output: {args.output}")
         return 1
 

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -14,18 +14,20 @@ from download_uup import parse_args
 class TestDownloadBuildBuildInfoFastPath(unittest.TestCase):
     """Tests that download_build reuses a supplied build_info and skips the API call."""
 
-    @patch('download_uup.get_build_info')
+    @patch("download_uup.get_build_info")
     def test_build_info_provided_skips_api_call(self, mock_get_build_info):
         """When build_info is passed in, get_build_info must not be called."""
         # Passing an empty files dict causes an early return ("No files found"),
         # so no filesystem or network activity is needed.
         build_info = {"files": {}}
-        result = download_uup.download_build("fake-id", "/tmp/out", build_info=build_info)
+        result = download_uup.download_build(
+            "fake-id", "/tmp/out", build_info=build_info
+        )
 
         mock_get_build_info.assert_not_called()
         self.assertFalse(result)
 
-    @patch('download_uup.get_build_info', return_value=None)
+    @patch("download_uup.get_build_info", return_value=None)
     def test_no_build_info_calls_api(self, mock_get_build_info):
         """When build_info is not passed, get_build_info is called."""
         result = download_uup.download_build("fake-id", "/tmp/out")
@@ -34,12 +36,14 @@ class TestDownloadBuildBuildInfoFastPath(unittest.TestCase):
 
 
 class TestCheckDependencies(unittest.TestCase):
-    @patch('shutil.which')
-    @patch('download_uup.log_error')
-    @patch('download_uup.log_info')
-    def test_check_dependencies_all_present(self, mock_log_info, mock_log_error, mock_which):
+    @patch("shutil.which")
+    @patch("download_uup.log_error")
+    @patch("download_uup.log_info")
+    def test_check_dependencies_all_present(
+        self, mock_log_info, mock_log_error, mock_which
+    ):
         # Mock shutil.which to return a path for aria2c
-        mock_which.return_value = '/usr/bin/aria2c'
+        mock_which.return_value = "/usr/bin/aria2c"
 
 
 class TestDownloadUUP(unittest.TestCase):
@@ -153,15 +157,12 @@ class TestHelpers(unittest.TestCase):
         dl_list = [{"url": "http://test", "name": "test.esd"}]
         mock_glob.return_value = [Path("test.esd")]
 
-        result = download_uup._run_aria2_download(
-            Path("out"), Path("in.txt"), dl_list
-        )
+        result = download_uup._run_aria2_download(Path("out"), Path("in.txt"), dl_list)
 
         self.assertTrue(result)
         mock_run.assert_called_once()
         mock_unlink.assert_called_once()
         mock_log_success.assert_called()
-
 
 
 class TestGetLatestBuilds(unittest.TestCase):
@@ -191,14 +192,17 @@ class TestGetLatestBuilds(unittest.TestCase):
     @patch("download_uup.log_error")
     def test_get_latest_builds_json_decode_error(self, mock_log_error, mock_fetch_url):
         # Simulate an invalid JSON string
-        mock_fetch_url.return_value = 'Not a JSON string'
+        mock_fetch_url.return_value = "Not a JSON string"
 
         result = download_uup.get_latest_builds()
 
         self.assertIsNone(result)
         # Since the error message includes the exception string, we just check that it starts correctly
         mock_log_error.assert_called_once()
-        self.assertTrue(mock_log_error.call_args[0][0].startswith("Failed to parse JSON response:"))
+        self.assertTrue(
+            mock_log_error.call_args[0][0].startswith("Failed to parse JSON response:")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,90 @@
+import sys
+import unittest
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add the scripts directory to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import download_uup
+
+
+class TestSecurity(unittest.TestCase):
+    def setUp(self):
+        self.script_dir = Path(download_uup.__file__).parent
+        self.project_root = self.script_dir.parent.resolve()
+
+    def test_path_traversal_prevention(self):
+        """Test that path traversal is correctly prevented."""
+
+        with patch("download_uup.parse_args") as mock_parse_args, patch(
+            "download_uup.check_dependencies", return_value=True
+        ), patch("download_uup.log_error") as mock_log_error:
+
+            # Case 1: Normal relative path (Safe)
+            mock_parse_args.return_value = MagicMock(
+                output="uup_files", list=False, build_id=None
+            )
+            with patch("download_uup.interactive_mode", return_value=True):
+                self.assertEqual(download_uup.main(), 0)
+                mock_log_error.assert_not_called()
+
+            # Case 2: Absolute path inside project (Safe)
+            safe_abs_path = str(self.project_root / "custom_output")
+            mock_parse_args.return_value = MagicMock(
+                output=safe_abs_path, list=False, build_id=None
+            )
+            with patch("download_uup.interactive_mode", return_value=True):
+                self.assertEqual(download_uup.main(), 0)
+                mock_log_error.assert_not_called()
+
+            # Case 3: Path traversal attempt (Unsafe)
+            unsafe_path = "../../../etc/passwd"
+            mock_parse_args.return_value = MagicMock(
+                output=unsafe_path, list=False, build_id=None
+            )
+            self.assertEqual(download_uup.main(), 1)
+            mock_log_error.assert_called_with(
+                f"Path traversal attempt detected for output: {unsafe_path}"
+            )
+            mock_log_error.reset_mock()
+
+            # Case 4: Exploiting the startswith vulnerability (Now FIXED)
+            malicious_path_str = str(self.project_root) + "_malicious"
+
+            with patch("pathlib.Path.resolve") as mock_resolve:
+                # Order in main():
+                # 1. output_dir.resolve()
+                # 2. project_root.resolve()
+                # 3. output_dir.resolve() (called again in the relative_to check)
+
+                # NOTE: In the fixed version, output_dir.resolve() is called twice if it passes the first check.
+                # Actually, in the fixed version:
+                # 1. output_dir.resolve().relative_to(...)
+                #    Inside this, resolve() is called.
+                #    And project_root.resolve() is called.
+
+                mock_resolve.side_effect = [Path(malicious_path_str), self.project_root]
+
+                mock_parse_args.return_value = MagicMock(
+                    output="uup_files_malicious", list=False, build_id=None
+                )
+
+                result = download_uup.main()
+                # Now it SHOULD return 1 because Path("/app/project_malicious").relative_to("/app/project") raises ValueError
+                self.assertEqual(
+                    result,
+                    1,
+                    "Security fix failed: path outside root was still accepted!",
+                )
+                mock_log_error.assert_called_with(
+                    f"Path traversal attempt detected for output: uup_files_malicious"
+                )
+                print(
+                    "\nSECURITY TEST: Fix verified! Path outside root was correctly rejected."
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `scripts/download_uup.py`.
⚠️ **Risk:** The previous implementation used `startswith` on path strings, which could be bypassed if a malicious output directory shared a common prefix with the project root (e.g., if the project is in `/app/win11`, a path like `/app/win11_hacked` would be accepted).
🛡️ **Solution:** Switched to `pathlib`'s `relative_to()` method after resolving paths, which validates path components rather than raw strings, ensuring the output directory is strictly within the project hierarchy. Added security tests to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [13425315302413225753](https://jules.google.com/task/13425315302413225753) started by @Ven0m0*