### PR TITLE
🔒 Fix path traversal vulnerability in filename sanitization

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -257,14 +257,27 @@ def _run_aria2_download(output_path, aria2_input, download_list):
                 or "\n" in item["name"]
                 or "\r" in item["name"]
             ):
-                log_error(
-                    f"Invalid characters in URL or filename: {item['name']}"
-                )
+                log_error(f"Invalid characters in URL or filename: {item['name']}")
                 return False
 
             f.write(f"{item['url']}\n")
-            # Security: Sanitize filename to prevent path traversal
+            # Security: Sanitize filename and prevent path traversal
             safe_name = Path(item["name"].replace("\\", "/")).name
+
+            if not safe_name or safe_name in (".", ".."):
+                log_error(f"Invalid filename detected: {item['name']}")
+                return False
+
+            try:
+                resolved_output = output_path.resolve()
+                target_path = resolved_output.joinpath(safe_name).resolve()
+                target_path.relative_to(resolved_output)
+            except (ValueError, RuntimeError):
+                log_error(
+                    f"Path traversal attempt detected in filename: {item['name']}"
+                )
+                return False
+
             f.write(f"  out={safe_name}\n")
     # Download using aria2
     log_info("Starting download with aria2c...")
@@ -397,7 +410,9 @@ def interactive_mode(output_dir):
                     .lower()
                 )
                 if confirm == "" or confirm == "y":
-                    return download_build(build_id, output_dir, edition_filter, build_info=build_info)
+                    return download_build(
+                        build_id, output_dir, edition_filter, build_info=build_info
+                    )
                 else:
                     log_info("Download cancelled")
                     return False

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -162,6 +161,26 @@ class TestHelpers(unittest.TestCase):
         mock_unlink.assert_called_once()
         mock_log_success.assert_called()
 
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    @patch("download_uup.log_error")
+    def test_run_aria2_download_path_traversal(self, mock_log_error, mock_open):
+        """Ensure path traversal attempts in filename are rejected."""
+        test_cases = [
+            {"url": "http://test", "name": ".."},
+            {"url": "http://test", "name": "a/.."},
+            {"url": "http://test", "name": "."},
+            {"url": "http://test", "name": ""},
+        ]
+
+        for idx, item in enumerate(test_cases):
+            with self.subTest(name=item["name"]):
+                result = download_uup._run_aria2_download(
+                    Path("/tmp/out"), Path("in.txt"), [item]
+                )
+                self.assertFalse(result)
+                mock_log_error.assert_called()
+                mock_log_error.reset_mock()
+
 
 class TestGetLatestBuilds(unittest.TestCase):
     @patch("download_uup.fetch_url")
@@ -202,28 +221,31 @@ class TestGetLatestBuilds(unittest.TestCase):
         )
 
 
-
 class TestSelectEditions(unittest.TestCase):
     @patch("download_uup.log_warn")
     def test_select_editions_no_esd_files(self, mock_log_warn):
         build_info = {"files": {"test.txt": {"size": 100}}}
         result = download_uup.select_editions(build_info)
         self.assertIsNone(result)
-        mock_log_warn.assert_called_with("No edition-specific files found, will download all files")
+        mock_log_warn.assert_called_with(
+            "No edition-specific files found, will download all files"
+        )
 
     @patch("download_uup.log_warn")
     def test_select_editions_no_matching_esd_files(self, mock_log_warn):
         build_info = {"files": {"unknown.esd": {"size": 100}}}
         result = download_uup.select_editions(build_info)
         self.assertIsNone(result)
-        mock_log_warn.assert_called_with("No edition-specific files found, will download all files")
+        mock_log_warn.assert_called_with(
+            "No edition-specific files found, will download all files"
+        )
 
     @patch("builtins.input", return_value="")
     def test_select_editions_empty_choice(self, mock_input):
         build_info = {
             "files": {
                 "Windows_Professional.esd": {"size": 100},
-                "Windows_Home.esd": {"size": 100}
+                "Windows_Home.esd": {"size": 100},
             }
         }
         result = download_uup.select_editions(build_info)
@@ -231,11 +253,7 @@ class TestSelectEditions(unittest.TestCase):
 
     @patch("builtins.input", return_value="A")
     def test_select_editions_all_choice(self, mock_input):
-        build_info = {
-            "files": {
-                "Windows_Professional.esd": {"size": 100}
-            }
-        }
+        build_info = {"files": {"Windows_Professional.esd": {"size": 100}}}
         result = download_uup.select_editions(build_info)
         self.assertIsNone(result)
 
@@ -246,7 +264,7 @@ class TestSelectEditions(unittest.TestCase):
         build_info = {
             "files": {
                 "Windows_Professional.esd": {"size": 100},
-                "Windows_Home.esd": {"size": 100}
+                "Windows_Home.esd": {"size": 100},
             }
         }
         result = download_uup.select_editions(build_info)
@@ -258,11 +276,7 @@ class TestSelectEditions(unittest.TestCase):
     @patch("download_uup.log_warn")
     @patch("builtins.input", return_value="invalid")
     def test_select_editions_non_numeric_choice(self, mock_input, mock_log_warn):
-        build_info = {
-            "files": {
-                "Windows_Professional.esd": {"size": 100}
-            }
-        }
+        build_info = {"files": {"Windows_Professional.esd": {"size": 100}}}
         result = download_uup.select_editions(build_info)
         self.assertIsNone(result)
         mock_log_warn.assert_called_with("Invalid selection, downloading all editions")
@@ -270,11 +284,7 @@ class TestSelectEditions(unittest.TestCase):
     @patch("download_uup.log_warn")
     @patch("builtins.input", return_value="99")
     def test_select_editions_out_of_range_choice(self, mock_input, mock_log_warn):
-        build_info = {
-            "files": {
-                "Windows_Professional.esd": {"size": 100}
-            }
-        }
+        build_info = {"files": {"Windows_Professional.esd": {"size": 100}}}
         result = download_uup.select_editions(build_info)
         self.assertIsNone(result)
         mock_log_warn.assert_called_with("Invalid selection, downloading all editions")


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `_run_aria2_download` function incorrectly sanitized filenames for downloaded artifacts using only `Path(name).name`. Attackers could exploit this using names that resolve to `..` or empty paths, enabling directory traversal to overwrite the parent of the output directory when aria2c downloads the file.

⚠️ **Risk:** The potential impact if left unfixed
An attacker controlling the API response from UUP Dump (e.g. via DNS spoofing or if UUP Dump was compromised) could specify filenames that write files anywhere on the file system relative to the download directory.

🛡️ **Solution:** How the fix addresses the vulnerability
The new code validates that the final resolved path for each file resides strictly within the resolved `output_path` using `Path.resolve().relative_to(output_path.resolve())`. Explicit checks reject filenames consisting entirely of `.` or `..` or empty strings. A new security test class verifies these checks.

---
*PR created automatically by Jules for task [72138804305439624](https://jules.google.com/task/72138804305439624) started by @Ven0m0*