### PR TITLE
🔒 [security] Fix Path Injection in wimlib-imagex update via Config File

### DIFF
--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -55,6 +55,13 @@ if [[ -f "$CONFIG_FILE" ]]; then
     line=$(echo "$line" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
     [[ -z "$line" ]] && continue
     [[ "$line" =~ ^# ]] && continue
+
+    # Validate pattern to prevent path injection
+    if [[ ! "$line" =~ ^[a-zA-Z0-9.*_-]+$ ]]; then
+      log_warn "Skipping invalid pattern: $line"
+      continue
+    fi
+
     PATTERNS+=("$line")
   done <"$CONFIG_FILE"
 fi


### PR DESCRIPTION
- 🎯 **What:** Fixed a path injection vulnerability in `scripts/debloat_wim.sh` where patterns from the configuration file were directly used in `wimlib-imagex` commands.
- ⚠️ **Risk:** A malicious pattern in `config/debloat_list.txt` could have been used to inject arbitrary `wimlib-imagex` commands, potentially leading to unauthorized file deletion or modification within the Windows image.
- 🛡️ **Solution:** Implemented a strict allowlist validation for patterns using a regular expression (`^[a-zA-Z0-9.*_-]+$`). Any pattern containing invalid characters (like quotes, spaces, or directory traversal sequences) is now skipped and logged.

---
*PR created automatically by Jules for task [7098244732012084672](https://jules.google.com/task/7098244732012084672) started by @Ven0m0*