### PR TITLE
Fix item_icon_space drawing issue in minegrub theme

### DIFF
--- a/ventoy/ventoy/themes/minegrub/theme.txt
+++ b/ventoy/ventoy/themes/minegrub/theme.txt
@@ -20,7 +20,8 @@ terminal-font: "Monocraft Regular 22"
 	height = 100%-289
 
 	item_font = "Minecraft Regular 30"
-	item_color = "#ffffff"
+	item_color = "transparent"
+	selected_item_color = "transparent"
     item_padding = 16
     # height+spacing should equals 108
     item_height = 96
@@ -31,7 +32,7 @@ terminal-font: "Monocraft Regular 22"
 
     icon_width = 1
     icon_height = 1
-    item_icon_space = 2000  # Temp fix, draw with empty font instead
+    item_icon_space = 0
 }
 
 ### Icon and Description (one file, see ./icons/)
@@ -42,7 +43,8 @@ terminal-font: "Monocraft Regular 22"
 	height = 100%-289
 
 	item_font = "Minecraft Regular 30"
-	item_color = "#ffffff"
+	item_color = "transparent"
+	selected_item_color = "transparent"
     item_padding = 16
     # height+spacing should equals 108
     # Info: pixmaps are drawn in spacing, which may fuck with where the text is drawn
@@ -54,7 +56,7 @@ terminal-font: "Monocraft Regular 22"
 
     icon_width = 801
     icon_height = 96
-    item_icon_space = 2000  # Temp fix, draw with empty font instead
+    item_icon_space = 0
 }
 
 ### default image and item name


### PR DESCRIPTION
The `minegrub` theme inside `ventoy/ventoy/themes/minegrub/theme.txt` contained a temporary fix (`item_icon_space = 2000`) for hiding the text in some `boot_menu` blocks, combined with a comment suggesting an empty font would be a "better" workaround. However, pushing text offscreen with massive padding values can cause rendering or bounding box issues in GRUB.

This fixes the issue properly by:
- Defining `item_color = "transparent"` and `selected_item_color = "transparent"` so the text is hidden at the rendering level.
- Resetting `item_icon_space` back to `0`.
- Avoiding the need for an empty font entirely.

---
*PR created automatically by Jules for task [7380511972750619951](https://jules.google.com/task/7380511972750619951) started by @Ven0m0*