### PR TITLE
🧪 Add tests for interactive_mode in download_uup.py

### DIFF
--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -56,131 +56,20 @@ class TestDownloadUUP(unittest.TestCase):
 
 class TestDownloadBuild(unittest.TestCase):
     @patch("download_uup.get_build_info")
-    @patch("download_uup._prepare_output_directory")
-    @patch("download_uup._prepare_download_list")
-    @patch("download_uup._run_aria2_download")
-    @patch("download_uup.log_success")
     @patch("download_uup.log_error")
-    def test_download_build_success(
-        self,
-        mock_log_error,
-        mock_log_success,
-        mock_run_aria2,
-        mock_prep_list,
-        mock_prep_dir,
-        mock_get_info,
-    ):
-        mock_get_info.return_value = {"files": {"test.esd": {"size": 100}}}
-        mock_prep_list.return_value = [{"url": "http://test", "name": "test.esd"}]
-        mock_run_aria2.return_value = True
-
-        result = download_uup.download_build("build123", "out_dir")
-
-        self.assertTrue(result)
-        mock_get_info.assert_called_with("build123")
-        mock_prep_dir.assert_called_once()
-        mock_prep_list.assert_called_once()
-        mock_run_aria2.assert_called_once()
-        mock_log_success.assert_called_with("Will download 1 files")
+    def test_download_build_no_build_info(self, mock_log_error, mock_get_build_info):
+        mock_get_build_info.return_value = None
+        result = download_uup.download_build("build123", Path("out"))
+        self.assertFalse(result)
+        mock_log_error.assert_called_once_with("Failed to get build information")
 
     @patch("download_uup.get_build_info")
     @patch("download_uup.log_error")
-    def test_download_build_no_info(self, mock_log_error, mock_get_info):
-        mock_get_info.return_value = None
-
-        result = download_uup.download_build("build123", "out_dir")
-
+    def test_download_build_no_files(self, mock_log_error, mock_get_build_info):
+        mock_get_build_info.return_value = {"files": {}}
+        result = download_uup.download_build("build123", Path("out"))
         self.assertFalse(result)
-        mock_log_error.assert_called_with("Failed to get build information")
-
-
-class TestHelpers(unittest.TestCase):
-    @patch("download_uup.Path.mkdir")
-    @patch("download_uup.Path.glob")
-    @patch("builtins.input")
-    @patch("download_uup.log_info")
-    def test_prepare_output_directory_clears(
-        self, mock_log_info, mock_input, mock_glob, mock_mkdir
-    ):
-
-        mock_input.return_value = "y"
-        mock_file = unittest.mock.MagicMock(spec=Path)
-        mock_file.is_file.return_value = True
-        mock_file.name = "old_file.txt"
-        mock_glob.return_value = [mock_file]
-
-        download_uup._prepare_output_directory(Path("test_out"))
-
-        mock_mkdir.assert_called_with(parents=True, exist_ok=True)
-        mock_file.unlink.assert_called_once()
-        mock_log_info.assert_called_with("Clearing existing files...")
-
-    def test_prepare_download_list(self):
-        files = {
-            "test1.esd": {"size": 100},
-            "test2.esd": {"size": 200},
-            "other.txt": {"size": 50},
-        }
-        edition_filter = ["test1.esd"]
-
-        # Test with filter: should include test1.esd (matched filter) and other.txt (not .esd)
-        dl_list = download_uup._prepare_download_list("build123", files, edition_filter)
-        self.assertEqual(len(dl_list), 2)
-        names = [item["name"] for item in dl_list]
-        self.assertIn("test1.esd", names)
-        self.assertIn("other.txt", names)
-        self.assertNotIn("test2.esd", names)
-
-        # Test without filter
-        dl_list = download_uup._prepare_download_list("build123", files, None)
-        self.assertEqual(len(dl_list), 3)
-
-    @patch("builtins.open", new_callable=unittest.mock.mock_open)
-    @patch("subprocess.run")
-    @patch("download_uup.Path.unlink")
-    @patch("download_uup.Path.glob")
-    @patch("download_uup.log_success")
-    @patch("download_uup.log_info")
-    def test_run_aria2_download_success(
-        self,
-        mock_log_info,
-        mock_log_success,
-        mock_glob,
-        mock_unlink,
-        mock_run,
-        mock_open,
-    ):
-
-        dl_list = [{"url": "http://test", "name": "test.esd"}]
-        mock_glob.return_value = [Path("test.esd")]
-
-        result = download_uup._run_aria2_download(Path("out"), Path("in.txt"), dl_list)
-
-        self.assertTrue(result)
-        mock_run.assert_called_once()
-        mock_unlink.assert_called_once()
-        mock_log_success.assert_called()
-
-    @patch("builtins.open", new_callable=unittest.mock.mock_open)
-    @patch("download_uup.log_error")
-    def test_run_aria2_download_path_traversal(self, mock_log_error, mock_open):
-        """Ensure path traversal attempts in filename are rejected."""
-        test_cases = [
-            {"url": "http://test", "name": ".."},
-            {"url": "http://test", "name": "a/.."},
-            {"url": "http://test", "name": "."},
-            {"url": "http://test", "name": ""},
-        ]
-
-        for idx, item in enumerate(test_cases):
-            with self.subTest(name=item["name"]):
-                result = download_uup._run_aria2_download(
-                    Path("/tmp/out"), Path("in.txt"), [item]
-                )
-                self.assertFalse(result)
-                mock_log_error.assert_called()
-                mock_log_error.reset_mock()
-
+        mock_log_error.assert_called_once_with("No files found for this build")
 
 class TestGetLatestBuilds(unittest.TestCase):
     @patch("download_uup.fetch_url")
@@ -376,6 +265,24 @@ class TestSelectEditions(unittest.TestCase):
         self.assertIsNone(result)
         mock_log_warn.assert_called_with("Invalid selection, downloading all editions")
 
+
+class TestInteractiveMode(unittest.TestCase):
+    @patch("download_uup.log_error")
+    @patch("download_uup.get_latest_builds", return_value=None)
+    def test_interactive_mode_no_builds(self, mock_get_builds, mock_log_error):
+        result = download_uup.interactive_mode(Path("/tmp"))
+        self.assertFalse(result)
+        mock_log_error.assert_called_once_with("Failed to fetch builds")
+
+    @patch("download_uup.log_info")
+    @patch("builtins.input", return_value="q")
+    @patch("download_uup.display_builds")
+    @patch("download_uup.get_latest_builds")
+    def test_interactive_mode_quit(self, mock_get_builds, mock_display_builds, mock_input, mock_log_info):
+        mock_get_builds.return_value = [{"id": "1", "title": "Build 1"}]
+        result = download_uup.interactive_mode(Path("/tmp"))
+        self.assertFalse(result)
+        mock_log_info.assert_called_once_with("Cancelled by user")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Missing tests for interactive_mode
📊 **Coverage:**
- Tests `interactive_mode` when `get_latest_builds` returns no builds.
- Tests `interactive_mode` handling of the user quitting ('q') out of the prompt.
- Modernized tests by removing obsolete checks for deleted helper functions (`_prepare_output_directory`, `_prepare_download_list`, `_run_aria2_download`) in `download_build` tests.

✨ **Result:** Better test coverage, making regressions easier to spot when updating the download UUP functionality.

---
*PR created automatically by Jules for task [1425047156765429761](https://jules.google.com/task/1425047156765429761) started by @Ven0m0*