### PR TITLE
🧹 [Refactor] Extract helper functions from download_build to improve readability

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -300,22 +300,9 @@ def select_editions(build_info):
     return None
 
 
-def download_build(build_id, output_dir, edition_filter=None, build_info=None):
-    """Download UUP files for a specific build"""
-    if build_info is None:
-        build_info = get_build_info(build_id)
-
-    if not build_info:
-        log_error("Failed to get build information")
-        return False
-
-    files = build_info.get("files", {})
-    if not files:
-        log_error("No files found for this build")
-        return False
-
+def _prepare_output_directory(output_dir):
+    """Create output directory and optionally clear existing files"""
     output_path = Path(output_dir)
-    # Create output directory and optionally clear existing files
     output_path.mkdir(parents=True, exist_ok=True)
     existing_files = list(output_path.glob("*"))
     if existing_files:
@@ -328,8 +315,11 @@ def download_build(build_id, output_dir, edition_filter=None, build_info=None):
             for f in existing_files:
                 if f.is_file() and f.name != ".gitkeep":
                     f.unlink()
+    return output_path
 
-    # Construct the list of files to download
+
+def _prepare_download_list(build_id, files, edition_filter, output_path):
+    """Construct the list of files to download and create aria2 input file"""
     download_list = []
     base_url = "https://uupdump.net/get.php"
     log_info(f"Preparing to download {len(files)} files...")
@@ -344,7 +334,7 @@ def download_build(build_id, output_dir, edition_filter=None, build_info=None):
 
     if not download_list:
         log_error("No files to download after filtering")
-        return False
+        return None, None
 
     log_success(f"Will download {len(download_list)} files")
 
@@ -358,12 +348,12 @@ def download_build(build_id, output_dir, edition_filter=None, build_info=None):
             or "\r" in item["name"]
         ):
             log_error(f"Invalid characters in URL or filename: {item['name']}")
-            return False
+            return None, None
 
         safe_name = os.path.basename(item["name"].replace("\\", "/"))
         if not safe_name or safe_name in (".", ".."):
             log_error(f"Invalid filename detected: {item['name']}")
-            return False
+            return None, None
 
         try:
             resolved_output = output_path.resolve()
@@ -371,14 +361,19 @@ def download_build(build_id, output_dir, edition_filter=None, build_info=None):
             target_path.relative_to(resolved_output)
         except (ValueError, RuntimeError):
             log_error(f"Path traversal attempt detected in filename: {item['name']}")
-            return False
+            return None, None
 
         lines.append(f"{item['url']}\n  out={safe_name}\n")
 
     with open(aria2_input, "w") as f:
         f.writelines(lines)
 
-    log_info("Starting download with aria2c...")
+    return download_list, aria2_input
+
+
+def _run_aria2_download(output_path, aria2_input, download_list):
+    """Run aria2c to download files using the generated input file"""
+    log_info(f"Starting download of {len(download_list)} files...")
     print(
         f"{Colors.BOLD}This may take a while depending on your connection...{Colors.RESET}\n"
     )
@@ -423,6 +418,31 @@ def download_build(build_id, output_dir, edition_filter=None, build_info=None):
         log_warn("\nDownload interrupted by user")
         aria2_input.unlink(missing_ok=True)
         return False
+
+
+def download_build(build_id, output_dir, edition_filter=None, build_info=None):
+    """Download UUP files for a specific build"""
+    if build_info is None:
+        build_info = get_build_info(build_id)
+
+    if not build_info:
+        log_error("Failed to get build information")
+        return False
+
+    files = build_info.get("files", {})
+    if not files:
+        log_error("No files found for this build")
+        return False
+
+    output_path = _prepare_output_directory(output_dir)
+
+    download_list, aria2_input = _prepare_download_list(
+        build_id, files, edition_filter, output_path
+    )
+    if not download_list or not aria2_input:
+        return False
+
+    return _run_aria2_download(output_path, aria2_input, download_list)
 
 
 def interactive_mode(output_dir):
@@ -530,41 +550,40 @@ For more information, visit: https://uupdump.net
     )
 
     parser.add_argument(
-        "-e", "--editions",
-        help="List available editions for a specific build ID and exit"
+        "-e",
+        "--editions",
+        help="List available editions for a specific build ID and exit",
     )
 
     parser.add_argument(
         "--languages",
         const="",
         nargs="?",
-        help="List available languages (optionally for a specific build ID)"
+        help="List available languages (optionally for a specific build ID)",
     )
 
     parser.add_argument(
         "--latest",
         action="store_true",
-        help="Fetch latest build info from Windows Update servers"
+        help="Fetch latest build info from Windows Update servers",
     )
 
     parser.add_argument(
         "--arch",
         default="amd64",
         choices=["amd64", "x86", "arm64", "all"],
-        help="Architecture for --latest (default: amd64)"
+        help="Architecture for --latest (default: amd64)",
     )
 
     parser.add_argument(
         "--ring",
         default="Retail",
         choices=["Dev", "Beta", "ReleasePreview", "Retail"],
-        help="Update ring for --latest (default: Retail)"
+        help="Update ring for --latest (default: Retail)",
     )
 
     parser.add_argument(
-        "--version",
-        action="store_true",
-        help="Show API version info and exit"
+        "--version", action="store_true", help="Show API version info and exit"
     )
 
     return parser.parse_args(args)
@@ -574,7 +593,13 @@ def main():
     args = parse_args()
 
     # Check dependencies (skip for info-only commands)
-    info_only = args.list or args.editions or args.languages is not None or args.latest or args.version
+    info_only = (
+        args.list
+        or args.editions
+        or args.languages is not None
+        or args.latest
+        or args.version
+    )
     if not info_only and not check_dependencies():
         return 1
 
@@ -582,10 +607,7 @@ def main():
     # Info-only modes should exit before any download/output-dir setup so they can
     # run without invoking normal-path dependency or filesystem checks.
     info_only_mode = (
-        args.version
-        or args.editions
-        or args.languages is not None
-        or args.latest
+        args.version or args.editions or args.languages is not None or args.latest
     )
 
     if info_only_mode:
@@ -594,7 +616,9 @@ def main():
             if version_info:
                 log_success("UUP dump API is online")
                 print(f"  API Version: {version_info.get('apiVersion', 'unknown')}")
-                print(f"  JSON API Version: {version_info.get('jsonApiVersion', 'unknown')}")
+                print(
+                    f"  JSON API Version: {version_info.get('jsonApiVersion', 'unknown')}"
+                )
                 return 0
             return 1
 
@@ -628,7 +652,9 @@ def main():
         if args.latest:
             latest_info = fetch_latest_from_wu(args.arch, args.ring)
             if latest_info:
-                print(f"\n{Colors.BOLD}Latest Build from Windows Update:{Colors.RESET}\n")
+                print(
+                    f"\n{Colors.BOLD}Latest Build from Windows Update:{Colors.RESET}\n"
+                )
                 print(f"  Update ID: {latest_info.get('updateId', 'N/A')}")
                 print(f"  Title: {latest_info.get('updateTitle', 'N/A')}")
                 print(f"  Build: {latest_info.get('foundBuild', 'N/A')}")


### PR DESCRIPTION
🎯 **What:** The `download_build` function in `scripts/download_uup.py` was too long and complex. We refactored it by extracting its core logic into three new helper functions: `_prepare_output_directory`, `_prepare_download_list`, and `_run_aria2_download`.
💡 **Why:** By extracting logical chunks into smaller helper functions, we improve readability, make testing easier, and reduce cyclomatic complexity. The logic of the downloader is now much clearer.
✅ **Verification:** We verified that `python3 -m unittest discover tests/` still runs and succeeds. We also ran `black scripts/download_uup.py` to ensure correct formatting and verified `bash -n scripts/*.sh` passed.
✨ **Result:** The code is much more manageable now!

---
*PR created automatically by Jules for task [14140031839344525802](https://jules.google.com/task/14140031839344525802) started by @Ven0m0*