### PR TITLE
🧹 inline single-use function generate_commands in debloat_wim.sh

### DIFF
--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -183,8 +183,8 @@ EOF
 }
 
 # Generate deletion commands
-generate_commands() {
-  local pattern
+CMD_FILE=$(mktemp)
+{
   for pattern in "${PATTERNS[@]}"; do
     echo "delete --recursive --force \"/Program Files/WindowsApps/$pattern\""
     echo "delete --recursive --force \"/ProgramData/Microsoft/Windows/AppRepository/Packages/$pattern\""
@@ -200,10 +200,7 @@ generate_commands() {
     echo "delete --recursive --force \"/Windows/Fonts/msyhl.ttc\""
     echo "delete --recursive --force \"/Windows/Fonts/msyhbd.ttc\""
   fi
-}
-
-CMD_FILE=$(mktemp)
-generate_commands >"$CMD_FILE"
+} >"$CMD_FILE"
 
 # Process each index
 for index in $(seq 1 "$IMAGE_COUNT"); do

--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -46,7 +46,7 @@ while IFS= read -r line; do
     EDITION_NAMES[CURRENT_INDEX]="${name%$'\r'}"
     CURRENT_INDEX=""
   fi
-done <<< "$WIM_INFO_OUTPUT"
+done <<<"$WIM_INFO_OUTPUT"
 
 # Parse config file
 PATTERNS=()
@@ -209,8 +209,8 @@ for index in $(seq 1 "$IMAGE_COUNT"); do
 
   # AppX Debloating
   if [[ ${#PATTERNS[@]} -gt 0 ]] || [[ "${NANO:-0}" == "1" ]]; then
-    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 \
-      | grep -v "does not exist" | head -n 20 || true
+    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 |
+      grep -v "does not exist" | head -n 20 || true
   fi
 
   # Registry Tweaking

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -12,14 +12,14 @@ source "$SCRIPT_DIR/utils.sh"
 log_info "Checking and installing dependencies..."
 
 # Detect package manager
-if command -v pacman &> /dev/null; then
+if command -v pacman &>/dev/null; then
   log_info "Detected Arch Linux (pacman)"
   sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
-elif command -v apt &> /dev/null; then
+elif command -v apt &>/dev/null; then
   log_info "Detected Debian/Ubuntu (apt)"
   sudo apt update
   sudo apt install -y aria2 cabextract wimtools chntpw genisoimage
-elif command -v dnf &> /dev/null; then
+elif command -v dnf &>/dev/null; then
   log_info "Detected Fedora (dnf)"
   sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
 else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,7 +21,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # =============================================================================
 check_tool() {
   local tool="$1"
-  if ! command -v "$tool" &> /dev/null; then
+  if ! command -v "$tool" &>/dev/null; then
     return 1
   else
     log_success "$tool found"
@@ -38,10 +38,10 @@ REQUIRED_TOOLS=("aria2c" "cabextract" "wimlib-imagex" "chntpw")
 # Returns 0 if genisoimage or mkisofs is found, 1 otherwise.
 # =============================================================================
 check_iso_tool() {
-  if command -v genisoimage &> /dev/null; then
+  if command -v genisoimage &>/dev/null; then
     log_success "genisoimage found"
     return 0
-  elif command -v mkisofs &> /dev/null; then
+  elif command -v mkisofs &>/dev/null; then
     log_success "mkisofs found"
     return 0
   else

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -92,8 +92,8 @@ log_info "Checking configuration files..."
 
 if [[ -f "$PROJECT_ROOT/config/debloat_list.txt" ]]; then
   log_success "debloat_list.txt found"
-  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" \
-    | grep -c -v "^[[:space:]]*$")
+  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" |
+    grep -c -v "^[[:space:]]*$")
   log_info "  → $pattern_count debloat patterns configured"
 else
   log_warn "debloat_list.txt not found - no apps will be removed"


### PR DESCRIPTION
This PR inlines the single-use function `generate_commands` in `scripts/debloat_wim.sh`.

🎯 **What:** The `generate_commands` function has been removed and its logic placed directly at the call site using a redirected brace group.
💡 **Why:** This improves maintainability and readability by reducing boilerplate for a short, one-off function.
✅ **Verification:** Verified with `bash -n scripts/debloat_wim.sh` and by running the Python unit test suite.
✨ **Result:** Cleaner code with less nesting and explicit function overhead for single-use logic.

---
*PR created automatically by Jules for task [8763779412176891347](https://jules.google.com/task/8763779412176891347) started by @Ven0m0*