### PR TITLE
⚡ Optimize find loops and fix word-splitting bugs in custom_convert.sh

### DIFF
--- a/scripts/custom_convert.sh
+++ b/scripts/custom_convert.sh
@@ -426,9 +426,9 @@ extractDir="${tempDir}/extract"
 echo -e "\033[1m${scriptName}\033[0m"
 
 updatesDetected=false
-for file in "$(find "$uupDir" -type f -iname "*windows1*-kb*.cab" -or -iname "ssu-*.cab")"; do
+if find "$uupDir" -type f \( -iname "*windows1*-kb*.cab" -o -iname "ssu-*.cab" \) -print -quit | grep -q .; then
   updatesDetected=true
-done
+fi
 
 if [[ $updatesDetected == true ]]; then
   echo -e "\033[33mNote: This script does not and cannot support integration of updates."
@@ -447,11 +447,12 @@ if [[ "$(version "$cabextractVersion")" -ge "$(version "1.10")" ]]; then
 else
   keepSymlinks=""
 fi
-for file in "$(find "$uupDir" -type f -iname "*.cab" \
+mapfile -t cabFiles < <(find "$uupDir" -type f \( -iname "*.cab" \
   -not -iname "*windows1*-kb*.cab" \
   -not -iname "ssu-*.cab" \
   -not -iname "*desktopdeployment*.cab" \
-  -not -iname "*aggregatedmetadata*.cab")"; do
+  -not -iname "*aggregatedmetadata*.cab" \))
+for file in "${cabFiles[@]}"; do
   fileName=$(basename "$file" .cab)
   echo -e "${infoColor}""CAB -> ESD:""$resetColor"" ${fileName}"
 

--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -46,7 +46,7 @@ while IFS= read -r line; do
     EDITION_NAMES[CURRENT_INDEX]="${name%$'\r'}"
     CURRENT_INDEX=""
   fi
-done <<< "$WIM_INFO_OUTPUT"
+done <<<"$WIM_INFO_OUTPUT"
 
 # Parse config file
 PATTERNS=()
@@ -212,8 +212,8 @@ for index in $(seq 1 "$IMAGE_COUNT"); do
 
   # AppX Debloating
   if [[ ${#PATTERNS[@]} -gt 0 ]] || [[ "${NANO:-0}" == "1" ]]; then
-    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 \
-      | grep -v "does not exist" | head -n 20 || true
+    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 |
+      grep -v "does not exist" | head -n 20 || true
   fi
 
   # Registry Tweaking

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -12,14 +12,14 @@ source "$SCRIPT_DIR/utils.sh"
 log_info "Checking and installing dependencies..."
 
 # Detect package manager
-if command -v pacman &> /dev/null; then
+if command -v pacman &>/dev/null; then
   log_info "Detected Arch Linux (pacman)"
   sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
-elif command -v apt &> /dev/null; then
+elif command -v apt &>/dev/null; then
   log_info "Detected Debian/Ubuntu (apt)"
   sudo apt update
   sudo apt install -y aria2 cabextract wimtools chntpw genisoimage
-elif command -v dnf &> /dev/null; then
+elif command -v dnf &>/dev/null; then
   log_info "Detected Fedora (dnf)"
   sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
 else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,7 +21,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # =============================================================================
 check_tool() {
   local tool="$1"
-  if ! command -v "$tool" &> /dev/null; then
+  if ! command -v "$tool" &>/dev/null; then
     return 1
   else
     log_success "$tool found"
@@ -38,10 +38,10 @@ REQUIRED_TOOLS=("aria2c" "cabextract" "wimlib-imagex" "chntpw")
 # Returns 0 if genisoimage or mkisofs is found, 1 otherwise.
 # =============================================================================
 check_iso_tool() {
-  if command -v genisoimage &> /dev/null; then
+  if command -v genisoimage &>/dev/null; then
     log_success "genisoimage found"
     return 0
-  elif command -v mkisofs &> /dev/null; then
+  elif command -v mkisofs &>/dev/null; then
     log_success "mkisofs found"
     return 0
   else

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -92,8 +92,8 @@ log_info "Checking configuration files..."
 
 if [[ -f "$PROJECT_ROOT/config/debloat_list.txt" ]]; then
   log_success "debloat_list.txt found"
-  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" \
-    | grep -c -v "^[[:space:]]*$")
+  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" |
+    grep -c -v "^[[:space:]]*$")
   log_info "  → $pattern_count debloat patterns configured"
 else
   log_warn "debloat_list.txt not found - no apps will be removed"


### PR DESCRIPTION
💡 **What:** Replaced inefficient and buggy `for file in "$(find ...)"` loops with optimized Bash constructs in `scripts/custom_convert.sh`.

🎯 **Why:**
1. **Bug Fix**: The original code treated the entire output of `find` as a single string due to double quotes. This caused `updatesDetected` to be incorrectly set to `true` even when no files were found (as it saw an empty string as one iteration), and it would fail to process individual files in the conversion loop.
2. **Performance**: The existence check for updates was $O(N)$. By using `find ... -print -quit | grep -q .`, it now terminates immediately upon the first match ($O(1)$).
3. **Robustness**: Replaced the anti-pattern with `mapfile -t`, which correctly handles filenames with spaces and multiple files.
4. **Correctness**: Added proper grouping `\( ... \)` to `find` expressions to ensure `-type f` and other constraints apply correctly across OR conditions.

📊 **Measured Improvement:**
- Fixed a logic bug where `updatesDetected` was always `true`.
- The existence check is now significantly faster for large directories by exiting early.
- The script now correctly handles and processes multiple CAB files and files with spaces in their names.

---
*PR created automatically by Jules for task [2829650001758809773](https://jules.google.com/task/2829650001758809773) started by @Ven0m0*