### PR TITLE
🧪 Add comprehensive tests for get_api_version

### DIFF
--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -46,7 +46,7 @@ while IFS= read -r line; do
     EDITION_NAMES[CURRENT_INDEX]="${name%$'\r'}"
     CURRENT_INDEX=""
   fi
-done <<< "$WIM_INFO_OUTPUT"
+done <<<"$WIM_INFO_OUTPUT"
 
 # Parse config file
 PATTERNS=()
@@ -212,8 +212,8 @@ for index in $(seq 1 "$IMAGE_COUNT"); do
 
   # AppX Debloating
   if [[ ${#PATTERNS[@]} -gt 0 ]] || [[ "${NANO:-0}" == "1" ]]; then
-    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 \
-      | grep -v "does not exist" | head -n 20 || true
+    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 |
+      grep -v "does not exist" | head -n 20 || true
   fi
 
   # Registry Tweaking

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -12,14 +12,14 @@ source "$SCRIPT_DIR/utils.sh"
 log_info "Checking and installing dependencies..."
 
 # Detect package manager
-if command -v pacman &> /dev/null; then
+if command -v pacman &>/dev/null; then
   log_info "Detected Arch Linux (pacman)"
   sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
-elif command -v apt &> /dev/null; then
+elif command -v apt &>/dev/null; then
   log_info "Detected Debian/Ubuntu (apt)"
   sudo apt update
   sudo apt install -y aria2 cabextract wimtools chntpw genisoimage
-elif command -v dnf &> /dev/null; then
+elif command -v dnf &>/dev/null; then
   log_info "Detected Fedora (dnf)"
   sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
 else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,7 +21,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # =============================================================================
 check_tool() {
   local tool="$1"
-  if ! command -v "$tool" &> /dev/null; then
+  if ! command -v "$tool" &>/dev/null; then
     return 1
   else
     log_success "$tool found"
@@ -38,10 +38,10 @@ REQUIRED_TOOLS=("aria2c" "cabextract" "wimlib-imagex" "chntpw")
 # Returns 0 if genisoimage or mkisofs is found, 1 otherwise.
 # =============================================================================
 check_iso_tool() {
-  if command -v genisoimage &> /dev/null; then
+  if command -v genisoimage &>/dev/null; then
     log_success "genisoimage found"
     return 0
-  elif command -v mkisofs &> /dev/null; then
+  elif command -v mkisofs &>/dev/null; then
     log_success "mkisofs found"
     return 0
   else

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -92,8 +92,8 @@ log_info "Checking configuration files..."
 
 if [[ -f "$PROJECT_ROOT/config/debloat_list.txt" ]]; then
   log_success "debloat_list.txt found"
-  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" \
-    | grep -c -v "^[[:space:]]*$")
+  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" |
+    grep -c -v "^[[:space:]]*$")
   log_info "  → $pattern_count debloat patterns configured"
 else
   log_warn "debloat_list.txt not found - no apps will be removed"

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -408,5 +408,34 @@ class TestInteractiveMode(unittest.TestCase):
         mock_log_info.assert_called_once_with("Cancelled by user")
 
 
+class TestGetApiVersion(unittest.TestCase):
+    @patch("download_uup.fetch_url")
+    def test_get_api_version_success(self, mock_fetch_url):
+        mock_fetch_url.return_value = '{"response": {"version": "1.0.0"}}'
+        result = download_uup.get_api_version()
+        self.assertEqual(result, {"version": "1.0.0"})
+        mock_fetch_url.assert_called_once_with("https://api.uupdump.net/")
+
+    @patch("download_uup.fetch_url")
+    def test_get_api_version_fetch_fails(self, mock_fetch_url):
+        mock_fetch_url.return_value = None
+        result = download_uup.get_api_version()
+        self.assertIsNone(result)
+
+    @patch("download_uup.log_error")
+    @patch("download_uup.fetch_url")
+    def test_get_api_version_invalid_json(self, mock_fetch_url, mock_log_error):
+        mock_fetch_url.return_value = "Invalid JSON!"
+        result = download_uup.get_api_version()
+        self.assertIsNone(result)
+        mock_log_error.assert_called_once()
+
+    @patch("download_uup.fetch_url")
+    def test_get_api_version_no_response_key(self, mock_fetch_url):
+        mock_fetch_url.return_value = '{"other_key": "value"}'
+        result = download_uup.get_api_version()
+        self.assertEqual(result, {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was a lack of unit tests for the `get_api_version` function in `scripts/download_uup.py`.

📊 **Coverage:** The new `TestGetApiVersion` test class in `tests/test_download_uup.py` now includes test cases for:
- Happy path: Successful fetch and valid JSON extraction.
- Failed fetch: `fetch_url` returning `None`.
- Invalid JSON: Proper handling of `json.JSONDecodeError` and logging fallback.
- Valid JSON without "response" key: Ensures defaulting to an empty dictionary `{}`.

✨ **Result:** Test coverage for `get_api_version` has been completed. The module test suite reliably verifies its resilience against network and formatting issues.

---
*PR created automatically by Jules for task [7095079008841391720](https://jules.google.com/task/7095079008841391720) started by @Ven0m0*