### PR TITLE
🧪 test: interactive_mode exception handling in download_uup.py

### DIFF
--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -46,7 +46,7 @@ while IFS= read -r line; do
     EDITION_NAMES[CURRENT_INDEX]="${name%$'\r'}"
     CURRENT_INDEX=""
   fi
-done <<< "$WIM_INFO_OUTPUT"
+done <<<"$WIM_INFO_OUTPUT"
 
 # Parse config file
 PATTERNS=()
@@ -212,8 +212,8 @@ for index in $(seq 1 "$IMAGE_COUNT"); do
 
   # AppX Debloating
   if [[ ${#PATTERNS[@]} -gt 0 ]] || [[ "${NANO:-0}" == "1" ]]; then
-    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 \
-      | grep -v "does not exist" | head -n 20 || true
+    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 |
+      grep -v "does not exist" | head -n 20 || true
   fi
 
   # Registry Tweaking

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -12,14 +12,14 @@ source "$SCRIPT_DIR/utils.sh"
 log_info "Checking and installing dependencies..."
 
 # Detect package manager
-if command -v pacman &> /dev/null; then
+if command -v pacman &>/dev/null; then
   log_info "Detected Arch Linux (pacman)"
   sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
-elif command -v apt &> /dev/null; then
+elif command -v apt &>/dev/null; then
   log_info "Detected Debian/Ubuntu (apt)"
   sudo apt update
   sudo apt install -y aria2 cabextract wimtools chntpw genisoimage
-elif command -v dnf &> /dev/null; then
+elif command -v dnf &>/dev/null; then
   log_info "Detected Fedora (dnf)"
   sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
 else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,7 +21,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # =============================================================================
 check_tool() {
   local tool="$1"
-  if ! command -v "$tool" &> /dev/null; then
+  if ! command -v "$tool" &>/dev/null; then
     return 1
   else
     log_success "$tool found"
@@ -38,10 +38,10 @@ REQUIRED_TOOLS=("aria2c" "cabextract" "wimlib-imagex" "chntpw")
 # Returns 0 if genisoimage or mkisofs is found, 1 otherwise.
 # =============================================================================
 check_iso_tool() {
-  if command -v genisoimage &> /dev/null; then
+  if command -v genisoimage &>/dev/null; then
     log_success "genisoimage found"
     return 0
-  elif command -v mkisofs &> /dev/null; then
+  elif command -v mkisofs &>/dev/null; then
     log_success "mkisofs found"
     return 0
   else

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -92,8 +92,8 @@ log_info "Checking configuration files..."
 
 if [[ -f "$PROJECT_ROOT/config/debloat_list.txt" ]]; then
   log_success "debloat_list.txt found"
-  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" \
-    | grep -c -v "^[[:space:]]*$")
+  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" |
+    grep -c -v "^[[:space:]]*$")
   log_info "  → $pattern_count debloat patterns configured"
 else
   log_warn "debloat_list.txt not found - no apps will be removed"

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -407,6 +407,30 @@ class TestInteractiveMode(unittest.TestCase):
         self.assertFalse(result)
         mock_log_info.assert_called_once_with("Cancelled by user")
 
+    @patch("download_uup.log_warn")
+    @patch("builtins.input", side_effect=["invalid", "q"])
+    @patch("download_uup.display_builds")
+    @patch("download_uup.get_latest_builds")
+    def test_interactive_mode_value_error(
+        self, mock_get_builds, mock_display_builds, mock_input, mock_log_warn
+    ):
+        mock_get_builds.return_value = [{"id": "1", "title": "Build 1"}]
+        result = download_uup.interactive_mode(Path("/tmp"))
+        self.assertFalse(result)
+        mock_log_warn.assert_any_call("Invalid input. Please enter a number.")
+
+    @patch("download_uup.log_info")
+    @patch("builtins.input", side_effect=KeyboardInterrupt)
+    @patch("download_uup.display_builds")
+    @patch("download_uup.get_latest_builds")
+    def test_interactive_mode_keyboard_interrupt(
+        self, mock_get_builds, mock_display_builds, mock_input, mock_log_info
+    ):
+        mock_get_builds.return_value = [{"id": "1", "title": "Build 1"}]
+        result = download_uup.interactive_mode(Path("/tmp"))
+        self.assertFalse(result)
+        mock_log_info.assert_any_call("Cancelled by user")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** This PR adds missing test coverage for `interactive_mode` exception handling in `scripts/download_uup.py`.
📊 **Coverage:** Specifically, tests were added for catching `ValueError` during integer casting on bad inputs, and for handling `KeyboardInterrupt` (`Ctrl+C`) when waiting for prompt inputs. Both now correctly assert the logged behavior and early exits.
✨ **Result:** Improved test coverage and reliability for user prompts by validating the exception handling paths.

---
*PR created automatically by Jules for task [1483882336831896878](https://jules.google.com/task/1483882336831896878) started by @Ven0m0*