### PR TITLE
🧹 Refactor download_uup.py main() to improve code health

### DIFF
--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -46,7 +46,7 @@ while IFS= read -r line; do
     EDITION_NAMES[CURRENT_INDEX]="${name%$'\r'}"
     CURRENT_INDEX=""
   fi
-done <<< "$WIM_INFO_OUTPUT"
+done <<<"$WIM_INFO_OUTPUT"
 
 # Parse config file
 PATTERNS=()
@@ -212,8 +212,8 @@ for index in $(seq 1 "$IMAGE_COUNT"); do
 
   # AppX Debloating
   if [[ ${#PATTERNS[@]} -gt 0 ]] || [[ "${NANO:-0}" == "1" ]]; then
-    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 \
-      | grep -v "does not exist" | head -n 20 || true
+    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 |
+      grep -v "does not exist" | head -n 20 || true
   fi
 
   # Registry Tweaking

--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 #!/usr/bin/env python3
 """UUP File Downloader for Windows 11 ISO Builder
 Automates the download of UUP files from uupdump.net
@@ -569,6 +571,79 @@ For more information, visit: https://uupdump.net
     return parser.parse_args(args)
 
 
+def _handle_info_mode(args):
+    """Handles info-only modes and returns the appropriate exit code. Returns None if not handled."""
+    if args.version:
+        version_info = get_api_version()
+        if version_info:
+            log_success("UUP dump API is online")
+            print(f"  API Version: {version_info.get('apiVersion', 'unknown')}")
+            print(
+                f"  JSON API Version: {version_info.get('jsonApiVersion', 'unknown')}"
+            )
+            return 0
+        return 1
+
+    # List editions mode
+    if args.editions:
+        editions_info = get_available_editions(args.editions)
+        if editions_info:
+            print(f"\n{Colors.BOLD}Available Editions for Build:{Colors.RESET}\n")
+            edition_list = editions_info.get("editionList", [])
+            fancy_names = editions_info.get("editionFancyNames", {})
+            for edition in edition_list:
+                fancy_name = fancy_names.get(edition, edition)
+                print(f"  {Colors.CYAN}{edition}{Colors.RESET} - {fancy_name}")
+            return 0
+        return 1
+
+    # List languages mode
+    if args.languages is not None:
+        langs_info = get_available_languages(args.languages or None)
+        if langs_info:
+            print(f"\n{Colors.BOLD}Available Languages:{Colors.RESET}\n")
+            lang_list = langs_info.get("langList", [])
+            fancy_names = langs_info.get("langFancyNames", {})
+            for lang in lang_list:
+                fancy_name = fancy_names.get(lang, lang)
+                print(f"  {Colors.CYAN}{lang}{Colors.RESET} - {fancy_name}")
+            return 0
+        return 1
+
+    # Fetch latest from Windows Update
+    if args.latest:
+        latest_info = fetch_latest_from_wu(args.arch, args.ring)
+        if latest_info:
+            print(f"\n{Colors.BOLD}Latest Build from Windows Update:{Colors.RESET}\n")
+            print(f"  Update ID: {latest_info.get('updateId', 'N/A')}")
+            print(f"  Title: {latest_info.get('updateTitle', 'N/A')}")
+            print(f"  Build: {latest_info.get('foundBuild', 'N/A')}")
+            print(f"  Arch: {latest_info.get('arch', 'N/A')}")
+            return 0
+        return 1
+
+    return None
+
+
+def _resolve_output_dir(output_arg: str) -> Optional[Path]:
+    """Resolves and validates the output directory to prevent traversal."""
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+
+    # Security: Resolve and validate output path to prevent traversal
+    output_dir = Path(output_arg)
+    if not output_dir.is_absolute():
+        output_dir = project_root.joinpath(output_dir)
+
+    try:
+        output_dir.resolve().relative_to(project_root.resolve())
+    except (ValueError, RuntimeError):
+        log_error(f"Path traversal attempt detected for output: {output_arg}")
+        return None
+
+    return output_dir
+
+
 def main():
     args = parse_args()
 
@@ -591,69 +666,12 @@ def main():
     )
 
     if info_only_mode:
-        if args.version:
-            version_info = get_api_version()
-            if version_info:
-                log_success("UUP dump API is online")
-                print(f"  API Version: {version_info.get('apiVersion', 'unknown')}")
-                print(
-                    f"  JSON API Version: {version_info.get('jsonApiVersion', 'unknown')}"
-                )
-                return 0
-            return 1
+        result = _handle_info_mode(args)
+        if result is not None:
+            return result
 
-        # List editions mode
-        if args.editions:
-            editions_info = get_available_editions(args.editions)
-            if editions_info:
-                print(f"\n{Colors.BOLD}Available Editions for Build:{Colors.RESET}\n")
-                edition_list = editions_info.get("editionList", [])
-                fancy_names = editions_info.get("editionFancyNames", {})
-                for edition in edition_list:
-                    fancy_name = fancy_names.get(edition, edition)
-                    print(f"  {Colors.CYAN}{edition}{Colors.RESET} - {fancy_name}")
-                return 0
-            return 1
-
-        # List languages mode
-        if args.languages is not None:
-            langs_info = get_available_languages(args.languages or None)
-            if langs_info:
-                print(f"\n{Colors.BOLD}Available Languages:{Colors.RESET}\n")
-                lang_list = langs_info.get("langList", [])
-                fancy_names = langs_info.get("langFancyNames", {})
-                for lang in lang_list:
-                    fancy_name = fancy_names.get(lang, lang)
-                    print(f"  {Colors.CYAN}{lang}{Colors.RESET} - {fancy_name}")
-                return 0
-            return 1
-
-        # Fetch latest from Windows Update
-        if args.latest:
-            latest_info = fetch_latest_from_wu(args.arch, args.ring)
-            if latest_info:
-                print(
-                    f"\n{Colors.BOLD}Latest Build from Windows Update:{Colors.RESET}\n"
-                )
-                print(f"  Update ID: {latest_info.get('updateId', 'N/A')}")
-                print(f"  Title: {latest_info.get('updateTitle', 'N/A')}")
-                print(f"  Build: {latest_info.get('foundBuild', 'N/A')}")
-                print(f"  Arch: {latest_info.get('arch', 'N/A')}")
-                return 0
-            return 1
-    # Resolve output directory
-    script_dir = Path(__file__).parent
-    project_root = script_dir.parent
-
-    # Security: Resolve and validate output path to prevent traversal
-    output_dir = Path(args.output)
-    if not output_dir.is_absolute():
-        output_dir = project_root.joinpath(output_dir)
-
-    try:
-        output_dir.resolve().relative_to(project_root.resolve())
-    except (ValueError, RuntimeError):
-        log_error(f"Path traversal attempt detected for output: {args.output}")
+    output_dir = _resolve_output_dir(args.output)
+    if not output_dir:
         return 1
 
     # List mode

--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 """UUP File Downloader for Windows 11 ISO Builder
 Automates the download of UUP files from uupdump.net

--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 #!/usr/bin/env python3
 """UUP File Downloader for Windows 11 ISO Builder
@@ -6,6 +5,7 @@ Automates the download of UUP files from uupdump.net
 """
 
 import sys
+from typing import Optional
 import json
 import argparse
 import shutil

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -12,14 +12,14 @@ source "$SCRIPT_DIR/utils.sh"
 log_info "Checking and installing dependencies..."
 
 # Detect package manager
-if command -v pacman &> /dev/null; then
+if command -v pacman &>/dev/null; then
   log_info "Detected Arch Linux (pacman)"
   sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
-elif command -v apt &> /dev/null; then
+elif command -v apt &>/dev/null; then
   log_info "Detected Debian/Ubuntu (apt)"
   sudo apt update
   sudo apt install -y aria2 cabextract wimtools chntpw genisoimage
-elif command -v dnf &> /dev/null; then
+elif command -v dnf &>/dev/null; then
   log_info "Detected Fedora (dnf)"
   sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
 else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,7 +21,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 # =============================================================================
 check_tool() {
   local tool="$1"
-  if ! command -v "$tool" &> /dev/null; then
+  if ! command -v "$tool" &>/dev/null; then
     return 1
   else
     log_success "$tool found"
@@ -38,10 +38,10 @@ REQUIRED_TOOLS=("aria2c" "cabextract" "wimlib-imagex" "chntpw")
 # Returns 0 if genisoimage or mkisofs is found, 1 otherwise.
 # =============================================================================
 check_iso_tool() {
-  if command -v genisoimage &> /dev/null; then
+  if command -v genisoimage &>/dev/null; then
     log_success "genisoimage found"
     return 0
-  elif command -v mkisofs &> /dev/null; then
+  elif command -v mkisofs &>/dev/null; then
     log_success "mkisofs found"
     return 0
   else

--- a/scripts/validate_prereqs.sh
+++ b/scripts/validate_prereqs.sh
@@ -92,8 +92,8 @@ log_info "Checking configuration files..."
 
 if [[ -f "$PROJECT_ROOT/config/debloat_list.txt" ]]; then
   log_success "debloat_list.txt found"
-  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" \
-    | grep -c -v "^[[:space:]]*$")
+  pattern_count=$(grep -v "^#" "$PROJECT_ROOT/config/debloat_list.txt" |
+    grep -c -v "^[[:space:]]*$")
   log_info "  → $pattern_count debloat patterns configured"
 else
   log_warn "debloat_list.txt not found - no apps will be removed"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -16,7 +16,7 @@ class TestSecurity(unittest.TestCase):
         project_root = Path("/tmp/project_root").resolve()
 
         def is_safe(output_arg, root):
-            # This replicates the logic in download_uup.main()
+            # This replicates the logic in download_uup._resolve_output_dir()
             output_dir = Path(output_arg)
             if not output_dir.is_absolute():
                 output_dir = root.joinpath(output_dir)


### PR DESCRIPTION
🎯 **What:** Extracted `_handle_info_mode()` and `_resolve_output_dir()` logic from the overly long `main()` function in `scripts/download_uup.py`. Updated `tests/test_security.py` to point to the newly extracted `_resolve_output_dir` function instead of `main()`.

💡 **Why:** Reduces the length and complexity of `main()`, separating distinct concerns (info mode handling and secure output directory resolution) into focused helper functions, thus improving maintainability and readability without altering existing behavior.

✅ **Verification:** Verified via `black` formatter, ensuring it followed Python code styles. Validated against the full test suite (`python3 -m unittest discover tests/`) demonstrating tests passed effectively, notably confirming that behavior including path traversal protections was preserved entirely.

✨ **Result:** A much cleaner, more concise `main()` function matching standard best-practices for Python scripts.

---
*PR created automatically by Jules for task [3880402872835303010](https://jules.google.com/task/3880402872835303010) started by @Ven0m0*