### PR TITLE
perf/fix/test: merge PRs #119–#134 — batch WIM ops, fetch_url caching, find loop fixes, new tests

### DIFF
--- a/scripts/custom_convert.sh
+++ b/scripts/custom_convert.sh
@@ -426,9 +426,9 @@ extractDir="${tempDir}/extract"
 echo -e "\033[1m${scriptName}\033[0m"
 
 updatesDetected=false
-for file in "$(find "$uupDir" -type f -iname "*windows1*-kb*.cab" -or -iname "ssu-*.cab")"; do
+if find "$uupDir" -type f \( -iname "*windows1*-kb*.cab" -o -iname "ssu-*.cab" \) -print -quit | grep -q .; then
   updatesDetected=true
-done
+fi
 
 if [[ $updatesDetected == true ]]; then
   echo -e "\033[33mNote: This script does not and cannot support integration of updates."
@@ -447,11 +447,12 @@ if [[ "$(version "$cabextractVersion")" -ge "$(version "1.10")" ]]; then
 else
   keepSymlinks=""
 fi
-for file in "$(find "$uupDir" -type f -iname "*.cab" \
+mapfile -t cabFiles < <(find "$uupDir" -type f \( -iname "*.cab" \
   -not -iname "*windows1*-kb*.cab" \
   -not -iname "ssu-*.cab" \
   -not -iname "*desktopdeployment*.cab" \
-  -not -iname "*aggregatedmetadata*.cab")"; do
+  -not -iname "*aggregatedmetadata*.cab" \))
+for file in "${cabFiles[@]}"; do
   fileName=$(basename "$file" .cab)
   echo -e "${infoColor}""CAB -> ESD:""$resetColor"" ${fileName}"
 
@@ -625,10 +626,25 @@ FALLBACK_EDITION="${FALLBACK_EDITION:-Professional}"
 # Pre-scan metadata to find target edition
 targetMetadata=""
 fallbackMetadata=""
-declare -A cachedInfo
+declare -a cachedInfoKeys=()
+declare -a cachedInfoVals=()
+
+get_wim_info() {
+  local metadata="$1"
+  local i
+  for (( i=0; i<${#cachedInfoKeys[@]}; i++ )); do
+    if [[ "${cachedInfoKeys[$i]}" == "$metadata" ]]; then
+      currentInfo="${cachedInfoVals[$i]}"
+      return 0
+    fi
+  done
+  currentInfo=$(wimlib-imagex info "$metadata" 3 2>/dev/null || true)
+  cachedInfoKeys+=("$metadata")
+  cachedInfoVals+=("$currentInfo")
+}
 for metadata in "${metadataFiles[@]}"; do
-  scanInfo=$(wimlib-imagex info "$metadata" 3 2>/dev/null)
-  cachedInfo["$metadata"]="$scanInfo"
+  get_wim_info "$metadata"
+  scanInfo="$currentInfo"
   scanEdition=$(grep -i "^Edition ID:" <<<"$scanInfo" | sed "s/.*  //g")
   if [[ "$scanEdition" == "$TARGET_EDITION" ]]; then
     targetMetadata="$metadata"
@@ -649,11 +665,8 @@ else
   echo -e "${errorColor}""Neither ${TARGET_EDITION} nor ${FALLBACK_EDITION} found in UUP files.""$resetColor"
   echo "Available editions:"
   for metadata in "${metadataFiles[@]}"; do
-    scanInfo="${cachedInfo["$metadata"]}"
-    if [[ -z "$scanInfo" ]]; then
-      scanInfo=$(wimlib-imagex info "$metadata" 3 2>/dev/null)
-      cachedInfo["$metadata"]="$scanInfo"
-    fi
+    get_wim_info "$metadata"
+    scanInfo="$currentInfo"
     scanEdition=$(grep -i "^Edition ID:" <<<"$scanInfo" | sed "s/.*  //g")
     echo "  - $scanEdition"
   done
@@ -663,11 +676,7 @@ fi
 echo ""
 indexesExported=0
 for metadata in "${metadataFiles[@]}"; do
-  currentInfo="${cachedInfo["$metadata"]}"
-  if [[ -z "$currentInfo" ]]; then
-    currentInfo=$(wimlib-imagex info "$metadata" 3)
-    cachedInfo["$metadata"]="$currentInfo"
-  fi
+  get_wim_info "$metadata"
 
   currentEdition=$(grep -i "^Edition ID:" <<<"$currentInfo" | sed "s/.*  //g")
   currentName=$(grep -i "^Name:" <<<"$currentInfo" | sed "s/.*  //g")
@@ -824,7 +833,7 @@ if [[ "${PAUSE_FOR_WINDOWS_STAGE:-0}" == "1" ]]; then
 fi
 
 echo -e "${infoColor}""Creating ISO image...""$resetColor"
-find ISODIR -exec touch {} +
+find ISODIR -print0 | xargs -0 -P 0 touch
 
 # Use mkisofs as fallback to genisoimage
 genisoimage="$(command -v genisoimage)"

--- a/scripts/debloat_wim.sh
+++ b/scripts/debloat_wim.sh
@@ -64,15 +64,18 @@ fi
 
 apply_registry_tweaks() {
   local index=$1
-  local temp_reg_dir
-  temp_reg_dir=$(mktemp -d)
+  local temp_reg_dir=$2
+  local index_cmd_file=$3
 
   log_info "Applying registry tweaks to index $index..."
 
+  # Extract SOFTWARE and SYSTEM hives in one pass
   wimlib-imagex extract "$WIM_FILE" "$index" \
     "/Windows/System32/config/SOFTWARE" \
+    "/Windows/System32/config/SYSTEM" \
     --dest-dir="$temp_reg_dir" --no-acls >/dev/null 2>&1 || true
 
+  # 1. SOFTWARE HIVE
   if [[ -f "$temp_reg_dir/SOFTWARE" ]]; then
     chntpw -e "$temp_reg_dir/SOFTWARE" <<EOF >/dev/null 2>&1
 nk Microsoft\Windows\CurrentVersion\CloudContent
@@ -110,15 +113,10 @@ ed HubMode
 q
 y
 EOF
-    wimlib-imagex update "$WIM_FILE" "$index" \
-      --command "add '$temp_reg_dir/SOFTWARE' '/Windows/System32/config/SOFTWARE'" \
-      >/dev/null 2>&1
+    echo "add '$temp_reg_dir/SOFTWARE' '/Windows/System32/config/SOFTWARE'" >>"$index_cmd_file"
   fi
 
-  wimlib-imagex extract "$WIM_FILE" "$index" \
-    "/Windows/System32/config/SYSTEM" \
-    --dest-dir="$temp_reg_dir" --no-acls >/dev/null 2>&1 || true
-
+  # 2. SYSTEM HIVE
   if [[ -f "$temp_reg_dir/SYSTEM" ]]; then
     {
       for cs in "ControlSet001" "ControlSet002" "ControlSet003"; do
@@ -162,50 +160,61 @@ EOF
       echo "q"
       echo "y"
     } | chntpw -e "$temp_reg_dir/SYSTEM" >/dev/null 2>&1
-    wimlib-imagex update "$WIM_FILE" "$index" \
-      --command "add '$temp_reg_dir/SYSTEM' '/Windows/System32/config/SYSTEM'" \
-      >/dev/null 2>&1
+    echo "add '$temp_reg_dir/SYSTEM' '/Windows/System32/config/SYSTEM'" >>"$index_cmd_file"
   fi
-
-  rm -rf "$temp_reg_dir"
 }
 
 CMD_FILE=$(mktemp)
-for pattern in "${PATTERNS[@]}"; do
-  echo "delete --recursive --force \"/Program Files/WindowsApps/$pattern\""
-  echo "delete --recursive --force \"/ProgramData/Microsoft/Windows/AppRepository/Packages/$pattern\""
-done
+{
+  for pattern in "${PATTERNS[@]}"; do
+    echo "delete --recursive --force \"/Program Files/WindowsApps/$pattern\""
+    echo "delete --recursive --force \"/ProgramData/Microsoft/Windows/AppRepository/Packages/$pattern\""
+  done
 
-if [[ "${NANO:-0}" == "1" ]]; then
-  echo "delete --recursive --force \"/Program Files (x86)/Microsoft/Edge\""
-  echo "delete --recursive --force \"/Program Files (x86)/Microsoft/EdgeCore\""
-  echo "delete --recursive --force \"/Program Files (x86)/Microsoft/EdgeUpdate\""
-  echo "delete --recursive --force \"/Windows/Fonts/malgun.ttf\""
-  echo "delete --recursive --force \"/Windows/Fonts/msjh.ttc\""
-  echo "delete --recursive --force \"/Windows/Fonts/msyh.ttc\""
-  echo "delete --recursive --force \"/Windows/Fonts/msyhl.ttc\""
-  echo "delete --recursive --force \"/Windows/Fonts/msyhbd.ttc\""
-fi >"$CMD_FILE"
+  if [[ "${NANO:-0}" == "1" ]]; then
+    echo "delete --recursive --force \"/Program Files (x86)/Microsoft/Edge\""
+    echo "delete --recursive --force \"/Program Files (x86)/Microsoft/EdgeCore\""
+    echo "delete --recursive --force \"/Program Files (x86)/Microsoft/EdgeUpdate\""
+    echo "delete --recursive --force \"/Windows/Fonts/malgun.ttf\""
+    echo "delete --recursive --force \"/Windows/Fonts/msjh.ttc\""
+    echo "delete --recursive --force \"/Windows/Fonts/msyh.ttc\""
+    echo "delete --recursive --force \"/Windows/Fonts/msyhl.ttc\""
+    echo "delete --recursive --force \"/Windows/Fonts/msyhbd.ttc\""
+  fi
+} >"$CMD_FILE"
 
 for index in $(seq 1 "$IMAGE_COUNT"); do
   EDITION="${EDITION_NAMES[$index]:-Unknown}"
   log_info "Processing index $index: $EDITION"
 
+  INDEX_CMD_FILE=$(mktemp)
+  TEMP_REG_DIR=$(mktemp -d)
+
+  # 1. AppX Debloating
   if [[ ${#PATTERNS[@]} -gt 0 ]] || [[ "${NANO:-0}" == "1" ]]; then
-    wimlib-imagex update "$WIM_FILE" "$index" <"$CMD_FILE" 2>&1 |
-      grep -v "does not exist" | head -n 20 || true
+    cat "$CMD_FILE" >"$INDEX_CMD_FILE"
   fi
 
-  apply_registry_tweaks "$index"
+  # 2. Registry Tweaking
+  apply_registry_tweaks "$index" "$TEMP_REG_DIR" "$INDEX_CMD_FILE"
 
+  # 3. WinSxS Slimming (Nano mode only)
   if [[ "${NANO:-0}" == "1" ]]; then
-    log_info "Performing WinSxS slimming for index $index..."
-    wimlib-imagex update "$WIM_FILE" "$index" <<EOF >/dev/null 2>&1 || true
+    log_info "Adding WinSxS slimming commands for index $index..."
+    cat >>"$INDEX_CMD_FILE" <<EOF
 delete --recursive --force "/Windows/WinSxS/Backup"
 delete --recursive --force "/Windows/WinSxS/ManifestCache"
 delete --recursive --force "/Windows/WinSxS/Temp"
 EOF
   fi
+
+  # Execute batched update
+  if [[ -s "$INDEX_CMD_FILE" ]]; then
+    wimlib-imagex update "$WIM_FILE" "$index" <"$INDEX_CMD_FILE" 2>&1 |
+      grep -v "does not exist" | head -n 20 || true
+  fi
+
+  rm -rf "$TEMP_REG_DIR" "$INDEX_CMD_FILE"
 done
 
 rm -f "$CMD_FILE"

--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -4,11 +4,8 @@ Automates the download of UUP files from uupdump.net
 """
 
 import sys
-<<<<<<< HEAD
-from typing import Optional
-=======
 import os
->>>>>>> pr-126
+from typing import Optional
 import json
 import argparse
 import shutil
@@ -59,16 +56,36 @@ def check_dependencies():
     return True
 
 
-def fetch_url(url, headers=None, data=None):
-    """Fetch URL with error handling"""
+_url_cache = {}
+
+
+def fetch_url(url, headers=None, data=None, return_json=False):
+    """Fetch URL with error handling and optional caching"""
     if headers is None:
         headers = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"}
+
+    cache_key = f"{url}:{return_json}" if not data else None
+    if cache_key and cache_key in _url_cache:
+        return _url_cache[cache_key]
+
     try:
         if data:
             data = urlencode(data).encode("utf-8")
         req = Request(url, headers=headers, data=data)
         with urlopen(req, timeout=30) as response:
-            return response.read().decode("utf-8")
+            result = response.read().decode("utf-8")
+
+            if return_json:
+                try:
+                    result = json.loads(result)
+                except json.JSONDecodeError as e:
+                    log_error(f"Failed to parse JSON response: {e}")
+                    return None
+
+            if cache_key:
+                _url_cache[cache_key] = result
+
+            return result
     except HTTPError as e:
         log_error(f"HTTP Error {e.code}: {e.reason}")
         return None
@@ -84,44 +101,31 @@ def get_latest_builds(max_results=10):
     """Fetch latest Windows 11 builds from uupdump.net API"""
     log_info("Fetching latest Windows 11 builds from uupdump.net...")
 
-    # UUPDump API endpoint for listing builds
     api_url = "https://api.uupdump.net/listid.php"
-
-    # Search for Windows 11 builds
     params = {"search": "windows 11", "sortByDate": "1"}
-
     url = f"{api_url}?{urlencode(params)}"
-    response = fetch_url(url)
+    data = fetch_url(url, return_json=True)
 
-    if not response:
+    if not data:
         log_error("Failed to fetch builds from uupdump.net")
         return None
 
-    try:
-        data = json.loads(response)
-        if data.get("response", {}).get("error"):
-            log_error(f"API Error: {data['response']['error']}")
-            return None
-
-        builds = data.get("response", {}).get("builds", {})
-        if not builds:
-            log_warn("No builds found in API response")
-            return []
-
-        # Convert to list and sort by date
-        build_list = []
-        for build_id, build_info in builds.items():
-            build_info["id"] = build_id
-            build_list.append(build_info)
-
-        # Sort by created timestamp (newest first)
-        build_list.sort(key=lambda x: int(x.get("created") or 0), reverse=True)
-
-        return build_list[:max_results]
-
-    except json.JSONDecodeError as e:
-        log_error(f"Failed to parse JSON response: {e}")
+    if data.get("response", {}).get("error"):
+        log_error(f"API Error: {data['response']['error']}")
         return None
+
+    builds = data.get("response", {}).get("builds", {})
+    if not builds:
+        log_warn("No builds found in API response")
+        return []
+
+    build_list = []
+    for build_id, build_info in builds.items():
+        build_info["id"] = build_id
+        build_list.append(build_info)
+
+    build_list.sort(key=lambda x: int(x.get("created") or 0), reverse=True)
+    return build_list[:max_results]
 
 
 def display_builds(builds):
@@ -144,21 +148,16 @@ def get_build_info(build_id):
     log_info(f"Fetching build information for ID: {build_id}")
 
     api_url = f"https://api.uupdump.net/get.php?id={build_id}"
-    response = fetch_url(api_url)
+    data = fetch_url(api_url, return_json=True)
 
-    if not response:
+    if not data:
         return None
 
-    try:
-        data = json.loads(response)
-        if data.get("response", {}).get("error"):
-            log_error(f"API Error: {data['response']['error']}")
-            return None
-
-        return data.get("response")
-    except json.JSONDecodeError as e:
-        log_error(f"Failed to parse JSON response: {e}")
+    if data.get("response", {}).get("error"):
+        log_error(f"API Error: {data['response']['error']}")
         return None
+
+    return data.get("response")
 
 
 def get_available_editions(build_id):
@@ -167,22 +166,17 @@ def get_available_editions(build_id):
 
     params = {"id": build_id, "lang": "en-us"}
     api_url = f"https://api.uupdump.net/listeditions.php?{urlencode(params)}"
-    response = fetch_url(api_url)
+    data = fetch_url(api_url, return_json=True)
 
-    if not response:
+    if not data:
         return None
 
-    try:
-        data = json.loads(response)
-        response_data = data.get("response") or {}
-        if response_data.get("error"):
-            log_error(f"API Error: {response_data['error']}")
-            return None
-
-        return response_data
-    except json.JSONDecodeError as e:
-        log_error(f"Failed to parse JSON response: {e}")
+    response_data = data.get("response") or {}
+    if response_data.get("error"):
+        log_error(f"API Error: {response_data['error']}")
         return None
+
+    return response_data
 
 
 def get_available_languages(build_id=None):
@@ -195,21 +189,16 @@ def get_available_languages(build_id=None):
         log_info("Fetching all available languages")
         api_url = "https://api.uupdump.net/listlangs.php"
 
-    response = fetch_url(api_url)
+    data = fetch_url(api_url, return_json=True)
 
-    if not response:
+    if not data:
         return None
 
-    try:
-        data = json.loads(response)
-        if data.get("response", {}).get("error"):
-            log_error(f"API Error: {data['response']['error']}")
-            return None
-
-        return data.get("response", {})
-    except json.JSONDecodeError as e:
-        log_error(f"Failed to parse JSON response: {e}")
+    if data.get("response", {}).get("error"):
+        log_error(f"API Error: {data['response']['error']}")
         return None
+
+    return data.get("response", {})
 
 
 def fetch_latest_from_wu(arch="amd64", ring="Retail"):
@@ -218,38 +207,28 @@ def fetch_latest_from_wu(arch="amd64", ring="Retail"):
 
     params = {"arch": arch, "ring": ring}
     api_url = f"https://api.uupdump.net/fetchupd.php?{urlencode(params)}"
-    response = fetch_url(api_url)
+    data = fetch_url(api_url, return_json=True)
 
-    if not response:
+    if not data:
         log_warn("Failed to fetch from Windows Update, falling back to cached builds")
         return None
 
-    try:
-        data = json.loads(response)
-        if data.get("response", {}).get("error"):
-            log_error(f"API Error: {data['response']['error']}")
-            return None
-
-        return data.get("response", {})
-    except json.JSONDecodeError as e:
-        log_error(f"Failed to parse JSON response: {e}")
+    if data.get("response", {}).get("error"):
+        log_error(f"API Error: {data['response']['error']}")
         return None
+
+    return data.get("response", {})
 
 
 def get_api_version():
     """Get the current UUP dump API version"""
     api_url = "https://api.uupdump.net/"
-    response = fetch_url(api_url)
+    data = fetch_url(api_url, return_json=True)
 
-    if not response:
+    if not data:
         return None
 
-    try:
-        data = json.loads(response)
-        return data.get("response", {})
-    except json.JSONDecodeError as e:
-        log_error(f"Failed to parse JSON response: {e}")
-        return None
+    return data.get("response", {})
 
 
 def select_editions(build_info):
@@ -673,63 +652,8 @@ def main():
         if result is not None:
             return result
 
-<<<<<<< HEAD
     output_dir = _resolve_output_dir(args.output)
     if not output_dir:
-=======
-        # List editions mode
-        if args.editions:
-            editions_info = get_available_editions(args.editions)
-            if editions_info:
-                print(f"\n{Colors.BOLD}Available Editions for Build:{Colors.RESET}\n")
-                edition_list = editions_info.get("editionList", [])
-                fancy_names = editions_info.get("editionFancyNames", {})
-                for edition in edition_list:
-                    fancy_name = fancy_names.get(edition, edition)
-                    print(f"  {Colors.CYAN}{edition}{Colors.RESET} - {fancy_name}")
-                return 0
-            return 1
-
-        # List languages mode
-        if args.languages is not None:
-            langs_info = get_available_languages(args.languages or None)
-            if langs_info:
-                print(f"\n{Colors.BOLD}Available Languages:{Colors.RESET}\n")
-                lang_list = langs_info.get("langList", [])
-                fancy_names = langs_info.get("langFancyNames", {})
-                for lang in lang_list:
-                    fancy_name = fancy_names.get(lang, lang)
-                    print(f"  {Colors.CYAN}{lang}{Colors.RESET} - {fancy_name}")
-                return 0
-            return 1
-
-        # Fetch latest from Windows Update
-        if args.latest:
-            latest_info = fetch_latest_from_wu(args.arch, args.ring)
-            if latest_info:
-                print(
-                    f"\n{Colors.BOLD}Latest Build from Windows Update:{Colors.RESET}\n"
-                )
-                print(f"  Update ID: {latest_info.get('updateId', 'N/A')}")
-                print(f"  Title: {latest_info.get('updateTitle', 'N/A')}")
-                print(f"  Build: {latest_info.get('foundBuild', 'N/A')}")
-                print(f"  Arch: {latest_info.get('arch', 'N/A')}")
-                return 0
-            return 1
-    # Resolve output directory
-    script_dir = Path(__file__).parent
-    project_root = script_dir.parent
-
-    # Security: Resolve and validate output path to prevent traversal
-    output_dir = Path(args.output)
-    if not output_dir.is_absolute():
-        output_dir = project_root.joinpath(output_dir)
-
-    resolved_output = output_dir.resolve()
-    resolved_root = project_root.resolve()
-    if os.path.commonpath([resolved_output, resolved_root]) != str(resolved_root):
-        log_error(f"Path traversal attempt detected for output: {args.output}")
->>>>>>> pr-126
         return 1
 
     # List mode

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -124,8 +124,8 @@ class TestGetLatestBuilds(unittest.TestCase):
     @patch("download_uup.fetch_url")
     @patch("download_uup.log_error")
     def test_get_latest_builds_api_error(self, mock_log_error, mock_fetch_url):
-        # Simulate API returning a JSON string with an error field
-        mock_fetch_url.return_value = '{"response": {"error": "Invalid request"}}'
+        # Simulate API returning a dict with an error field
+        mock_fetch_url.return_value = {"response": {"error": "Invalid request"}}
 
         result = download_uup.get_latest_builds()
 
@@ -146,42 +146,34 @@ class TestGetLatestBuilds(unittest.TestCase):
     @patch("download_uup.fetch_url")
     @patch("download_uup.log_error")
     def test_get_latest_builds_json_decode_error(self, mock_log_error, mock_fetch_url):
-        # Simulate an invalid JSON string
-        mock_fetch_url.return_value = "Not a JSON string"
+        # fetch_url returns None when JSON parsing fails
+        mock_fetch_url.return_value = None
 
         result = download_uup.get_latest_builds()
 
         self.assertIsNone(result)
-        # Since the error message includes the exception string, we just check that it starts correctly
-        mock_log_error.assert_called_once()
-        self.assertTrue(
-            mock_log_error.call_args[0][0].startswith("Failed to parse JSON response:")
-        )
+        mock_log_error.assert_called_with("Failed to fetch builds from uupdump.net")
 
     @patch("download_uup.fetch_url")
     def test_get_latest_builds_success(self, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {
-                "response": {
-                    "builds": {
-                        "build-1": {
-                            "title": "Windows 11 Build 1",
-                            "created": "1600000000",
-                        },
-                        "build-2": {
-                            "title": "Windows 11 Build 2",
-                            "created": "1620000000",
-                        },
-                        "build-3": {
-                            "title": "Windows 11 Build 3",
-                            "created": "1610000000",
-                        },
-                    }
+        mock_fetch_url.return_value = {
+            "response": {
+                "builds": {
+                    "build-1": {
+                        "title": "Windows 11 Build 1",
+                        "created": "1600000000",
+                    },
+                    "build-2": {
+                        "title": "Windows 11 Build 2",
+                        "created": "1620000000",
+                    },
+                    "build-3": {
+                        "title": "Windows 11 Build 3",
+                        "created": "1610000000",
+                    },
                 }
             }
-        )
+        }
 
         result = download_uup.get_latest_builds(max_results=2)
 
@@ -198,7 +190,7 @@ class TestFetchLatestFromWU(unittest.TestCase):
     @patch("download_uup.fetch_url")
     @patch("download_uup.log_error")
     def test_fetch_latest_from_wu_api_error(self, mock_log_error, mock_fetch_url):
-        mock_fetch_url.return_value = '{"response": {"error": "Invalid ring"}}'
+        mock_fetch_url.return_value = {"response": {"error": "Invalid ring"}}
         result = download_uup.fetch_latest_from_wu()
         self.assertIsNone(result)
         mock_log_error.assert_called_with("API Error: Invalid ring")
@@ -214,32 +206,27 @@ class TestFetchLatestFromWU(unittest.TestCase):
         )
 
     @patch("download_uup.fetch_url")
-    @patch("download_uup.log_error")
+    @patch("download_uup.log_warn")
     def test_fetch_latest_from_wu_json_decode_error(
-        self, mock_log_error, mock_fetch_url
+        self, mock_log_warn, mock_fetch_url
     ):
-        mock_fetch_url.return_value = "Not a JSON string"
+        mock_fetch_url.return_value = None
         result = download_uup.fetch_latest_from_wu()
         self.assertIsNone(result)
-        mock_log_error.assert_called_once()
-        self.assertTrue(
-            mock_log_error.call_args[0][0].startswith("Failed to parse JSON response:")
+        mock_log_warn.assert_called_with(
+            "Failed to fetch from Windows Update, falling back to cached builds"
         )
 
     @patch("download_uup.fetch_url")
     def test_fetch_latest_from_wu_success(self, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {
-                "response": {
-                    "updateId": "12345",
-                    "updateTitle": "Windows 11 Build",
-                    "foundBuild": "22621.1",
-                    "arch": "amd64",
-                }
+        mock_fetch_url.return_value = {
+            "response": {
+                "updateId": "12345",
+                "updateTitle": "Windows 11 Build",
+                "foundBuild": "22621.1",
+                "arch": "amd64",
             }
-        )
+        }
         result = download_uup.fetch_latest_from_wu(arch="amd64", ring="Retail")
         self.assertIsNotNone(result)
         self.assertEqual(result["updateId"], "12345")
@@ -251,48 +238,39 @@ class TestFetchLatestFromWU(unittest.TestCase):
 class TestGetBuildInfo(unittest.TestCase):
     @patch("download_uup.fetch_url")
     def test_get_build_info_success(self, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {"response": {"build": "info", "files": {}}}
-        )
+        mock_fetch_url.return_value = {"response": {"build": "info", "files": {}}}
 
         result = download_uup.get_build_info("fake-id")
 
         self.assertEqual(result, {"build": "info", "files": {}})
         mock_fetch_url.assert_called_once_with(
-            "https://api.uupdump.net/get.php?id=fake-id"
+            "https://api.uupdump.net/get.php?id=fake-id", return_json=True
         )
 
 
 class TestGetAvailableLanguages(unittest.TestCase):
     @patch("download_uup.fetch_url")
     def test_get_available_languages_with_build_id_success(self, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {"response": {"lang": "en-us", "langList": []}}
-        )
+        mock_fetch_url.return_value = {"response": {"lang": "en-us", "langList": []}}
 
         result = download_uup.get_available_languages("fake-id")
 
         self.assertEqual(result, {"lang": "en-us", "langList": []})
         mock_fetch_url.assert_called_once_with(
-            "https://api.uupdump.net/listlangs.php?id=fake-id"
+            "https://api.uupdump.net/listlangs.php?id=fake-id&lang=en-us",
+            return_json=True,
         )
 
     @patch("download_uup.fetch_url")
     def test_get_available_languages_no_build_id_success(self, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {"response": {"lang": "en-us", "langList": []}}
-        )
+        mock_fetch_url.return_value = {"response": {"lang": "en-us", "langList": []}}
 
         result = download_uup.get_available_languages()
 
         self.assertEqual(result, {"lang": "en-us", "langList": []})
-        mock_fetch_url.assert_called_once_with("https://api.uupdump.net/listlangs.php")
+        mock_fetch_url.assert_called_once_with(
+            "https://api.uupdump.net/listlangs.php", return_json=True
+        )
 
     @patch("download_uup.fetch_url")
     def test_get_available_languages_fetch_fails(self, mock_fetch_url):
@@ -302,22 +280,21 @@ class TestGetAvailableLanguages(unittest.TestCase):
 
     @patch("download_uup.fetch_url")
     def test_get_available_languages_api_error(self, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {"response": {"error": "Invalid build id"}}
-        )
+        mock_fetch_url.return_value = {"response": {"error": "Invalid build id"}}
         result = download_uup.get_available_languages("fake-id")
         self.assertIsNone(result)
 
     @patch("download_uup.fetch_url")
     def test_get_available_languages_json_error(self, mock_fetch_url):
-        mock_fetch_url.return_value = "invalid json"
+        mock_fetch_url.return_value = None
         result = download_uup.get_available_languages("fake-id")
         self.assertIsNone(result)
 
 
 class TestFetchUrl(unittest.TestCase):
+    def setUp(self):
+        download_uup._url_cache.clear()
+
     @patch("download_uup.urlopen")
     def test_fetch_url_success_get(self, mock_urlopen):
         mock_response = unittest.mock.MagicMock()

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -536,22 +536,43 @@ class TestInteractiveMode(unittest.TestCase):
         self.assertFalse(result)
         mock_log_info.assert_called_once_with("Cancelled by user")
 
+    @patch("download_uup.log_warn")
+    @patch("builtins.input", side_effect=["invalid", "q"])
+    @patch("download_uup.display_builds")
+    @patch("download_uup.get_latest_builds")
+    def test_interactive_mode_value_error(
+        self, mock_get_builds, mock_display_builds, mock_input, mock_log_warn
+    ):
+        mock_get_builds.return_value = [{"id": "1", "title": "Build 1"}]
+        result = download_uup.interactive_mode(Path("/tmp"))
+        self.assertFalse(result)
+        mock_log_warn.assert_any_call("Invalid input. Please enter a number.")
+
+    @patch("download_uup.log_info")
+    @patch("builtins.input", side_effect=KeyboardInterrupt)
+    @patch("download_uup.display_builds")
+    @patch("download_uup.get_latest_builds")
+    def test_interactive_mode_keyboard_interrupt(
+        self, mock_get_builds, mock_display_builds, mock_input, mock_log_info
+    ):
+        mock_get_builds.return_value = [{"id": "1", "title": "Build 1"}]
+        result = download_uup.interactive_mode(Path("/tmp"))
+        self.assertFalse(result)
+        mock_log_info.assert_any_call("Cancelled by user")
+
 
 class TestGetAvailableEditions(unittest.TestCase):
     @patch("download_uup.fetch_url")
     @patch("download_uup.log_info")
     def test_get_available_editions_success(self, mock_log_info, mock_fetch_url):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {"response": {"editionList": ["Core", "Professional"]}}
-        )
+        mock_fetch_url.return_value = {"response": {"editionList": ["Core", "Professional"]}}
 
         result = download_uup.get_available_editions("fake-build-id")
 
         self.assertEqual(result, {"editionList": ["Core", "Professional"]})
         mock_fetch_url.assert_called_once_with(
-            "https://api.uupdump.net/listeditions.php?id=fake-build-id&lang=en-us"
+            "https://api.uupdump.net/listeditions.php?id=fake-build-id&lang=en-us",
+            return_json=True,
         )
         mock_log_info.assert_called_once_with(
             "Fetching available editions for build: fake-build-id"
@@ -572,11 +593,7 @@ class TestGetAvailableEditions(unittest.TestCase):
     def test_get_available_editions_api_error(
         self, mock_log_info, mock_log_error, mock_fetch_url
     ):
-        import json
-
-        mock_fetch_url.return_value = json.dumps(
-            {"response": {"error": "Invalid build ID"}}
-        )
+        mock_fetch_url.return_value = {"response": {"error": "Invalid build ID"}}
 
         result = download_uup.get_available_editions("fake-build-id")
 
@@ -584,27 +601,26 @@ class TestGetAvailableEditions(unittest.TestCase):
         mock_log_error.assert_called_once_with("API Error: Invalid build ID")
 
     @patch("download_uup.fetch_url")
-    @patch("download_uup.log_error")
     @patch("download_uup.log_info")
     def test_get_available_editions_json_decode_error(
-        self, mock_log_info, mock_log_error, mock_fetch_url
+        self, mock_log_info, mock_fetch_url
     ):
-        mock_fetch_url.return_value = "invalid json"
+        mock_fetch_url.return_value = None
 
         result = download_uup.get_available_editions("fake-build-id")
 
         self.assertIsNone(result)
-        mock_log_error.assert_called_once()
-        self.assertIn("Failed to parse JSON response:", mock_log_error.call_args[0][0])
 
 
 class TestGetApiVersion(unittest.TestCase):
     @patch("download_uup.fetch_url")
     def test_get_api_version_success(self, mock_fetch_url):
-        mock_fetch_url.return_value = '{"response": {"version": "1.0.0"}}'
+        mock_fetch_url.return_value = {"response": {"version": "1.0.0"}}
         result = download_uup.get_api_version()
         self.assertEqual(result, {"version": "1.0.0"})
-        mock_fetch_url.assert_called_once_with("https://api.uupdump.net/")
+        mock_fetch_url.assert_called_once_with(
+            "https://api.uupdump.net/", return_json=True
+        )
 
     @patch("download_uup.fetch_url")
     def test_get_api_version_fetch_fails(self, mock_fetch_url):
@@ -612,17 +628,15 @@ class TestGetApiVersion(unittest.TestCase):
         result = download_uup.get_api_version()
         self.assertIsNone(result)
 
-    @patch("download_uup.log_error")
     @patch("download_uup.fetch_url")
-    def test_get_api_version_invalid_json(self, mock_fetch_url, mock_log_error):
-        mock_fetch_url.return_value = "Invalid JSON!"
+    def test_get_api_version_invalid_json(self, mock_fetch_url):
+        mock_fetch_url.return_value = None
         result = download_uup.get_api_version()
         self.assertIsNone(result)
-        mock_log_error.assert_called_once()
 
     @patch("download_uup.fetch_url")
     def test_get_api_version_no_response_key(self, mock_fetch_url):
-        mock_fetch_url.return_value = '{"other_key": "value"}'
+        mock_fetch_url.return_value = {"other_key": "value"}
         result = download_uup.get_api_version()
         self.assertEqual(result, {})
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Merges all 9 open PRs (#119, #120, #121, #122, #123, #125, #128, #130, #134) into a single clean squash commit, resolving overlapping changes intelligently.

### `scripts/debloat_wim.sh` (PRs #119, #125)
- Fix broken CMD_FILE generation: wrap for-loop + NANO block in `{ ... } >"$CMD_FILE"` so pattern deletions actually reach the file
- Batch all WIM operations per index into a single `wimlib-imagex update` call: AppX removal, registry hive adds, and WinSxS slimming now happen in one pass instead of 2–3 separate writes
- `apply_registry_tweaks` extracts both SOFTWARE and SYSTEM hives in one `wimlib-imagex extract` call; appends `add` commands to a per-index command file rather than calling `wimlib-imagex update` directly

### `scripts/custom_convert.sh` (PRs #120, #121, #122)
- **PR #120**: Replace broken `for file in "$(find ...)"` loops (treated all output as one string) with `find ... -print -quit | grep -q .` guard and `mapfile -t cabFiles < <(find ...)` + `for file in "${cabFiles[@]}"`; fixes `updatesDetected` always being `true` and handles filenames with spaces
- **PR #121**: Replace `find ISODIR -exec touch {} +` with `find ISODIR -print0 | xargs -0 -P 0 touch` for ~3.5× faster parallel timestamp updates
- **PR #122**: Replace `declare -A cachedInfo` (broken on Bash 3, causing 100% cache misses) with parallel indexed arrays + `get_wim_info()` helper; fixes repeated `wimlib-imagex info` calls

### `scripts/download_uup.py` (PR #123)
- Add `_url_cache` global and `return_json=False` param to `fetch_url`; JSON parsing and caching now happen inside `fetch_url`, eliminating boilerplate in every caller
- Refactor all API callers to use `return_json=True`; ~89% speedup on repeated API calls
- Resolve pre-existing merge conflict markers (keep HEAD's `_resolve_output_dir` approach)

### `tests/test_download_uup.py` (PRs #128, #130, #134)
- Update all existing `fetch_url` mocks from JSON strings to dicts (matching new `return_json=True` interface); add `return_json=True` to call assertions
- Add `setUp` to `TestFetchUrl` to clear `_url_cache` between tests
- Add `TestInteractiveMode.test_interactive_mode_value_error` and `test_interactive_mode_keyboard_interrupt` (PR #134)
- Simplify JSON-decode-error tests that are now handled inside `fetch_url`

## Test plan
- [ ] `bash -n scripts/debloat_wim.sh scripts/custom_convert.sh` — both pass
- [ ] `python3 -m py_compile scripts/download_uup.py tests/test_download_uup.py` — both pass
- [ ] All 52 unit tests pass
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzBQg9PF1RmApZdJdf6SwL)_