### PR TITLE
style: ruff format test_download_uup.py to fix CI lint failure

### DIFF
--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -565,7 +565,9 @@ class TestGetAvailableEditions(unittest.TestCase):
     @patch("download_uup.fetch_url")
     @patch("download_uup.log_info")
     def test_get_available_editions_success(self, mock_log_info, mock_fetch_url):
-        mock_fetch_url.return_value = {"response": {"editionList": ["Core", "Professional"]}}
+        mock_fetch_url.return_value = {
+            "response": {"editionList": ["Core", "Professional"]}
+        }
 
         result = download_uup.get_available_editions("fake-build-id")
 


### PR DESCRIPTION
Fixes the `Lint Python Scripts` CI failure on PR #141 — `ruff format --check` flagged a whitespace issue in `tests/test_download_uup.py`. Auto-fixed with `uvx ruff format`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzBQg9PF1RmApZdJdf6SwL)_