### PR TITLE
fix: address review comments on custom_convert.sh from PR #141

### DIFF
--- a/scripts/custom_convert.sh
+++ b/scripts/custom_convert.sh
@@ -426,7 +426,7 @@ extractDir="${tempDir}/extract"
 echo -e "\033[1m${scriptName}\033[0m"
 
 updatesDetected=false
-if find "$uupDir" -type f \( -iname "*windows1*-kb*.cab" -o -iname "ssu-*.cab" \) -print -quit | grep -q .; then
+if find "$uupDir" -type f \( -iname "*windows1*-kb*.cab" -o -iname "ssu-*.cab" \) -print | grep -q .; then
   updatesDetected=true
 fi
 
@@ -833,7 +833,7 @@ if [[ "${PAUSE_FOR_WINDOWS_STAGE:-0}" == "1" ]]; then
 fi
 
 echo -e "${infoColor}""Creating ISO image...""$resetColor"
-find ISODIR -print0 | xargs -0 -P 0 touch
+find ISODIR -print0 | xargs -0 -P "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8)" touch
 
 # Use mkisofs as fallback to genisoimage
 genisoimage="$(command -v genisoimage)"


### PR DESCRIPTION
Addresses two gemini-code-assist review comments from PR #141:

1. **Drop `-quit` from `find`** (line 429) — `-quit` is a GNU `find` extension unavailable on BSD `find`. Removed it; `grep -q` already terminates `find` early via SIGPIPE once it finds a match, so behavior is equivalent.

2. **Cap `xargs -P` to nproc** (line 836) — replaced `-P 0` (unlimited) with `-P "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8)"` to avoid spawning unbounded `touch` processes on very large ISODIR trees.

The third comment (`mapfile` / Bash 3 compat) is not applicable — `CLAUDE.md` explicitly states no macOS support and Linux is the only target, where Bash 4+ is universal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzBQg9PF1RmApZdJdf6SwL)_