### PR TITLE
🔒 [security] Remove sudo usage from setup scripts and tasks

### DIFF
--- a/.mise/tasks/install
+++ b/.mise/tasks/install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes
-sudo apt-get update -qq && sudo apt-get DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes install -yqq --no-install-recommends \
+apt-get update -qq && apt-get install -yqq --no-install-recommends \
   genisoimage libfuse2 aria2 cabextract wimtools chntpw
 [[ -f pyproject.toml ]] && uv sync --frozen || true
 [[ -f .venv/bin/activate ]] && source .venv/bin/activate

--- a/mise.toml
+++ b/mise.toml
@@ -51,9 +51,9 @@ _.python.venv = { path = ".venv", create = true, uv_create_args = ["--seed", "--
 # Install system dependencies
 install-deps = [
   """@if linux: if command -v pacman >/dev/null 2>&1; then
-    sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
+    pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
   elif command -v apt-get >/dev/null 2>&1; then
-    sudo apt update -qq && sudo apt install -yq aria2 cabextract wimtools chntpw genisoimage
+    apt update -qq && apt install -yq aria2 cabextract wimtools chntpw genisoimage
   else
     echo 'Unsupported Linux distribution: no supported package manager found (pacman, apt-get, or dnf).' >&2
     exit 1
@@ -129,7 +129,7 @@ file = '.mise/tasks/install'
 [tasks.linux]
 description = "Install build dependencies on Linux"
 run = [
-  "sudo pacman -Sq --needed aria2 cabextract wimlib chntpw cdrtools libxml2 2>/dev/null || (sudo apt update && sudo apt install -y aria2 cabextract wimtools chntpw genisoimage libxml2-utils) 2>/dev/null || (sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage libxml2)"
+  "pacman -Sq --needed aria2 cabextract wimlib chntpw cdrtools libxml2 2>/dev/null || (apt update && apt install -y aria2 cabextract wimtools chntpw genisoimage libxml2-utils) 2>/dev/null || (dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage libxml2)"
 ]
 
 [tasks.windows]
@@ -142,11 +142,11 @@ run = [
 # Aliases for platform-specific installs
 [tasks.arch]
 description = "Install deps (Arch Linux)"
-run = ["sudo pacman -Sq --needed aria2 cabextract wimlib chntpw cdrtools"]
+run = ["pacman -Sq --needed aria2 cabextract wimlib chntpw cdrtools"]
 
 [tasks.debian]
 description = "Install deps (Debian/Ubuntu)"
-run = ["sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-get install -yqq --no-install-recommends aria2 cabextract wimtools chntpw genisoimage libxml2-utils libfuse2"]
+run = ["apt-get update -qq && apt-get install -yqq --no-install-recommends aria2 cabextract wimtools chntpw genisoimage libxml2-utils libfuse2"]
 
 [tasks.test]
 description = "Run tests"

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -13,14 +13,14 @@ log_info "Checking and installing dependencies..."
 
 if command -v pacman &>/dev/null; then
   log_info "Detected Arch Linux (pacman)"
-  sudo pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
+  pacman -S --needed aria2 cabextract wimlib chntpw cdrtools
 elif command -v apt &>/dev/null; then
   log_info "Detected Debian/Ubuntu (apt)"
-  sudo apt update
-  sudo apt install -y aria2 cabextract wimtools chntpw genisoimage
+  apt update
+  apt install -y aria2 cabextract wimtools chntpw genisoimage
 elif command -v dnf &>/dev/null; then
   log_info "Detected Fedora (dnf)"
-  sudo dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
+  dnf install -y aria2 cabextract wimlib-utils chntpw genisoimage
 else
   log_error "Unsupported package manager. Please install manually:"
   echo "  - aria2 (download acceleration)"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -49,6 +49,38 @@ class TestSecurity(unittest.TestCase):
             f"Path {prefix_exploit_path} should be detected as traversal from {project_root}",
         )
 
+    def test_no_sudo_usage(self):
+        """
+        Verify that no shell scripts in the scripts/ directory use sudo or su.
+        This is a project-specific security invariant.
+        """
+        scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
+        scripts = list(scripts_dir.glob("*.sh"))
+
+        # Also check mise tasks and config scripts
+        mise_tasks_dir = Path(__file__).resolve().parent.parent / ".mise" / "tasks"
+        if mise_tasks_dir.exists():
+            scripts.extend(list(mise_tasks_dir.glob("*")))
+
+        # Commands to check for
+        forbidden_patterns = [r"\bsudo\b", r"\bsu\b"]
+
+        import re
+
+        for script in scripts:
+            if script.is_dir():
+                continue
+
+            content = script.read_text()
+            # Remove comments before checking to avoid false positives in documentation
+            content_no_comments = re.sub(r"#.*", "", content)
+
+            for pattern in forbidden_patterns:
+                self.assertFalse(
+                    re.search(pattern, content_no_comments),
+                    f"Forbidden command pattern '{pattern}' found in {script.relative_to(scripts_dir.parent)}",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of `sudo` within automated setup scripts and task definitions.
⚠️ **Risk:** Hardcoding `sudo` in scripts violates standard security hygiene, especially in CI/CD pipelines and restricted environments where privilege elevation should be explicitly controlled by the orchestrator.
🛡️ **Solution:** Removed all instances of `sudo` from `scripts/setup_env.sh`, `mise.toml`, and `.mise/tasks/install`. Added a security test to ensure no future shell scripts use `sudo` or `su`.

---
*PR created automatically by Jules for task [18020974516762215324](https://jules.google.com/task/18020974516762215324) started by @Ven0m0*