### PR TITLE
🧪 [testing improvement] Add tests for display_builds and empty guard

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -121,6 +121,10 @@ def get_latest_builds(max_results=10):
 
 def display_builds(builds):
     """Display builds in a user-friendly format"""
+    if not builds:
+        log_warn("No builds available.")
+        return
+
     print(f"\n{Colors.BOLD}Available Windows 11 Builds:{Colors.RESET}\n")
 
     for i, build in enumerate(builds, 1):

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -408,5 +408,57 @@ class TestInteractiveMode(unittest.TestCase):
         mock_log_info.assert_called_once_with("Cancelled by user")
 
 
+class TestDisplayBuilds(unittest.TestCase):
+    @patch("download_uup.log_warn")
+    def test_display_builds_empty(self, mock_log_warn):
+        download_uup.display_builds([])
+        mock_log_warn.assert_called_once_with("No builds available.")
+
+    @patch("builtins.print")
+    def test_display_builds_success(self, mock_print):
+        builds = [
+            {
+                "id": "build-1",
+                "title": "Windows 11 Test Build",
+                "build": "22621.1",
+                "arch": "amd64",
+                "created": "1600000000",
+            }
+        ]
+        download_uup.display_builds(builds)
+
+        # Check for title and build info in calls
+        calls = [call[0][0] for call in mock_print.call_args_list if call[0]]
+
+        # Check header
+        self.assertTrue(any("Available Windows 11 Builds" in c for c in calls))
+        # Check build details
+        self.assertTrue(any("[1]" in c and "Windows 11 Test Build" in c for c in calls))
+        self.assertTrue(
+            any(
+                "Build: 22621.1" in c
+                and "Arch: amd64" in c
+                and "Created: 1600000000" in c
+                for c in calls
+            )
+        )
+
+    @patch("builtins.print")
+    def test_display_builds_missing_fields(self, mock_print):
+        builds = [{"id": "build-1"}]
+        download_uup.display_builds(builds)
+
+        calls = [call[0][0] for call in mock_print.call_args_list if call[0]]
+
+        # Check for defaults
+        self.assertTrue(any("Unknown" in c for c in calls))  # Title
+        self.assertTrue(
+            any(
+                "Build: N/A" in c and "Arch: N/A" in c and "Created: N/A" in c
+                for c in calls
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR improves the reliability and coverage of the `scripts/download_uup.py` script by:
1. Adding a safety guard in `display_builds` to handle empty build lists gracefully.
2. Implementing a new suite of unit tests in `TestDisplayBuilds` to verify:
   - Empty input handling (logs a warning).
   - Successful output formatting for valid builds (includes title, build number, arch, and date).
   - Robustness when handling builds with missing fields (uses default values like "Unknown" and "N/A").

Total tests in `tests/test_download_uup.py` increased from 32 to 35, all passing.

---
*PR created automatically by Jules for task [7563456757455887082](https://jules.google.com/task/7563456757455887082) started by @Ven0m0*