### PR TITLE
🧪 [testing improvement] Add unit tests for display_builds

### DIFF
--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -186,6 +186,92 @@ class TestGetLatestBuilds(unittest.TestCase):
         self.assertEqual(result[1]["title"], "Windows 11 Build 3")
 
 
+class TestDisplayBuilds(unittest.TestCase):
+    @patch("builtins.print")
+    def test_empty_list(self, mock_print):
+        download_uup.display_builds([])
+        # Expect only the header print
+        self.assertEqual(mock_print.call_count, 1)
+        mock_print.assert_called_with(
+            f"\n{download_uup.Colors.BOLD}Available Windows 11 Builds:{download_uup.Colors.RESET}\n"
+        )
+
+    @patch("builtins.print")
+    def test_valid_builds(self, mock_print):
+        builds = [
+            {
+                "title": "Windows 11 Insider Preview 25309",
+                "build": "25309.1000",
+                "arch": "amd64",
+                "created": "1677686400",
+            },
+            {
+                "title": "Windows 11 Insider Preview 25300",
+                "build": "25300.1000",
+                "arch": "arm64",
+                "created": "1676476800",
+            },
+        ]
+
+        download_uup.display_builds(builds)
+
+        # Expected calls:
+        # 1. Header
+        # For each build (2 builds):
+        # 2. Title with index
+        # 3. Details line
+        # 4. Empty line
+        # Total calls: 1 + (3 * 2) = 7
+        self.assertEqual(mock_print.call_count, 7)
+
+        calls = mock_print.call_args_list
+        # Filter parameterless print() calls for empty lines to avoid IndexError if using call[0][0]
+        non_empty_calls = [c[0][0] for c in calls if c[0]]
+
+        self.assertEqual(
+            non_empty_calls[0],
+            f"\n{download_uup.Colors.BOLD}Available Windows 11 Builds:{download_uup.Colors.RESET}\n",
+        )
+
+        self.assertEqual(
+            non_empty_calls[1],
+            f"{download_uup.Colors.CYAN}[1]{download_uup.Colors.RESET} Windows 11 Insider Preview 25309",
+        )
+        self.assertEqual(
+            non_empty_calls[2],
+            "    Build: 25309.1000 | Arch: amd64 | Created: 1677686400",
+        )
+
+        self.assertEqual(
+            non_empty_calls[3],
+            f"{download_uup.Colors.CYAN}[2]{download_uup.Colors.RESET} Windows 11 Insider Preview 25300",
+        )
+        self.assertEqual(
+            non_empty_calls[4],
+            "    Build: 25300.1000 | Arch: arm64 | Created: 1676476800",
+        )
+
+    @patch("builtins.print")
+    def test_missing_keys(self, mock_print):
+        builds = [{}]  # Empty dict to test defaults
+
+        download_uup.display_builds(builds)
+
+        # Total calls: 1 (header) + 3 (for 1 build) = 4
+        self.assertEqual(mock_print.call_count, 4)
+
+        calls = mock_print.call_args_list
+        non_empty_calls = [c[0][0] for c in calls if c[0]]
+
+        self.assertEqual(
+            non_empty_calls[1],
+            f"{download_uup.Colors.CYAN}[1]{download_uup.Colors.RESET} Unknown",
+        )
+        self.assertEqual(
+            non_empty_calls[2], "    Build: N/A | Arch: N/A | Created: N/A"
+        )
+
+
 class TestFetchLatestFromWU(unittest.TestCase):
     @patch("download_uup.fetch_url")
     @patch("download_uup.log_error")


### PR DESCRIPTION
🎯 **What:** 
The issue addresses a lack of automated test coverage for the `display_builds` function in `scripts/download_uup.py`. This function takes a list of dictionary representations of Windows builds and formats them elegantly with colors into stdout for interactive user selection.

📊 **Coverage:**
- Added `TestDisplayBuilds` class to `tests/test_download_uup.py`.
- **`test_empty_list`**: Tests that when an empty list `[]` is passed, it prints the header without entering the loop, preventing unexpected output or errors.
- **`test_valid_builds`**: Checks the happy path, ensuring that a populated list of build dictionaries prints the title properly, iterates correctly, and outputs strings formatted as expected (including correctly injected variables like `title`, `build_num`, `arch`, etc., and proper terminal color codes like `Colors.CYAN` or `Colors.BOLD`). Uses filtering logic `if call[0]` to correctly match lines that include content and ignore empty `print()` calls inside `display_builds`.
- **`test_missing_keys`**: Tests edge cases and fallback logic in the `.get()` methods within the loop when some keys like `title`, `build`, `arch`, or `created` are missing or default. Verifies output values like `"Unknown"` or `"N/A"`.

✨ **Result:**
The test suite now accurately covers scenarios and formatting within the `display_builds` function. The build list view is verified using `@patch("builtins.print")` across diverse conditions, making this function much safer against regressions without producing `IndexError` when empty calls are fetched. Test count increased by 3 with passing validation suite via `unittest`.

---
*PR created automatically by Jules for task [15491928362808034029](https://jules.google.com/task/15491928362808034029) started by @Ven0m0*