### PR TITLE
🧹 convert_config.sh: fix unused VIRTUAL_EDITIONS_LIST format

### DIFF
--- a/scripts/convert_config.sh
+++ b/scripts/convert_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2034
 
-VIRTUAL_EDITIONS_LIST='ProfessionalWorkstation'
+VIRTUAL_EDITIONS_LIST=('ProfessionalWorkstation')

--- a/scripts/custom_convert.sh
+++ b/scripts/custom_convert.sh
@@ -320,7 +320,7 @@ if [ "$1" == "-?" -o "$1" == "--help" -o "$1" == "-h" ]; then
   echo "It is required to place configuration in the same directory as script."
   echo ""
   echo "Possible configuration options:"
-  echo "VIRTUAL_EDITIONS_LIST='space delimited editions sequence'"
+  echo "VIRTUAL_EDITIONS_LIST=('Edition1' 'Edition2')"
   echo ""
   echo -e "${infoColor}List of editions created if you enable virtual editions creation:${resetColor}"
   for edition in "${VIRTUAL_EDITIONS_LIST[@]}"; do
@@ -632,7 +632,7 @@ declare -a cachedInfoVals=()
 get_wim_info() {
   local metadata="$1"
   local i
-  for (( i=0; i<${#cachedInfoKeys[@]}; i++ )); do
+  for ((i = 0; i < ${#cachedInfoKeys[@]}; i++)); do
     if [[ "${cachedInfoKeys[$i]}" == "$metadata" ]]; then
       currentInfo="${cachedInfoVals[$i]}"
       return 0


### PR DESCRIPTION
🎯 What: Updated VIRTUAL_EDITIONS_LIST from string to bash array format in scripts/convert_config.sh.
💡 Why: In scripts/custom_convert.sh, VIRTUAL_EDITIONS_LIST is referenced as a bash array. Previously, as a simple string, it incorrectly iterated through the whole string as a single array element if the string had multiple space-delimited editions. Formatting it as an array ensures standard parsing and usage.
✅ Verification: Ran shellcheck, shfmt, and python3 -m unittest discover tests/. All tests pass. Confirmed script functionality with a test file proving correct array iteration behavior.
✨ Result: Correct configuration parsing improving maintainability.

---
*PR created automatically by Jules for task [11033981907937989502](https://jules.google.com/task/11033981907937989502) started by @Ven0m0*