### PR TITLE
🧪 Improve get_api_version testing and error handling

### DIFF
--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -236,7 +236,6 @@ def get_api_version():
         return None
 
 
-
 def select_editions(build_info):
     """Allow user to select which editions to download"""
     files = build_info.get("files", {})

--- a/scripts/download_uup.py
+++ b/scripts/download_uup.py
@@ -223,12 +223,18 @@ def fetch_latest_from_wu(arch="amd64", ring="Retail"):
 def get_api_version():
     """Get the current UUP dump API version"""
     api_url = "https://api.uupdump.net/"
-    data = fetch_url(api_url, return_json=True)
+    response = fetch_url(api_url)
 
-    if not data:
+    if not response:
         return None
 
-    return data.get("response", {})
+    try:
+        data = json.loads(response)
+        return data.get("response", {})
+    except json.JSONDecodeError as e:
+        log_error(f"Failed to parse JSON response: {e}")
+        return None
+
 
 
 def select_editions(build_info):

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -642,6 +642,6 @@ class TestGetApiVersion(unittest.TestCase):
         result = download_uup.get_api_version()
         self.assertEqual(result, {})
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_download_uup.py
+++ b/tests/test_download_uup.py
@@ -617,12 +617,10 @@ class TestGetAvailableEditions(unittest.TestCase):
 class TestGetApiVersion(unittest.TestCase):
     @patch("download_uup.fetch_url")
     def test_get_api_version_success(self, mock_fetch_url):
-        mock_fetch_url.return_value = {"response": {"version": "1.0.0"}}
+        mock_fetch_url.return_value = '{"response": {"version": "1.0.0"}}'
         result = download_uup.get_api_version()
         self.assertEqual(result, {"version": "1.0.0"})
-        mock_fetch_url.assert_called_once_with(
-            "https://api.uupdump.net/", return_json=True
-        )
+        mock_fetch_url.assert_called_once_with("https://api.uupdump.net/")
 
     @patch("download_uup.fetch_url")
     def test_get_api_version_fetch_fails(self, mock_fetch_url):
@@ -631,17 +629,19 @@ class TestGetApiVersion(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch("download_uup.fetch_url")
-    def test_get_api_version_invalid_json(self, mock_fetch_url):
-        mock_fetch_url.return_value = None
+    @patch("download_uup.log_error")
+    def test_get_api_version_invalid_json(self, mock_log_error, mock_fetch_url):
+        mock_fetch_url.return_value = "invalid json"
         result = download_uup.get_api_version()
         self.assertIsNone(result)
+        mock_log_error.assert_called_once()
 
     @patch("download_uup.fetch_url")
     def test_get_api_version_no_response_key(self, mock_fetch_url):
-        mock_fetch_url.return_value = {"other_key": "value"}
+        mock_fetch_url.return_value = '{"other_key": "value"}'
         result = download_uup.get_api_version()
         self.assertEqual(result, {})
 
-
 if __name__ == "__main__":
+
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `get_api_version` function in `scripts/download_uup.py` lacked robust error handling for JSON deserialization, relying entirely on the behavior of `fetch_url`. The unit tests for this function passed dict objects directly instead of string payloads for `fetch_url` responses.

📊 **Coverage:**
* Tested the `get_api_version` success response logic with proper string payloads instead of python dict objects directly.
* Tested scenario where `get_api_version` encounters a `json.JSONDecodeError` to verify proper error catching and `log_error` invocation.

✨ **Result:** Improved branch coverage by verifying exception handling logic, making the tests more authentic and robust.

---
*PR created automatically by Jules for task [5668033942862625376](https://jules.google.com/task/5668033942862625376) started by @Ven0m0*